### PR TITLE
replace deprecated AM_CONFIG_HEADER

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_SUBST(SOOP_VERSION)
 AC_SUBST(SOOP_RELEASE)
 
 AM_INIT_AUTOMAKE(sooperlooper,$SOOP_VERSION)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 dnl ====================================================================
 dnl you do have C++, right ?

--- a/libs/midi++/configure.ac
+++ b/libs/midi++/configure.ac
@@ -28,7 +28,7 @@ AC_SUBST(LIBMIDI_RELEASE)
 
 AM_INIT_AUTOMAKE(libmidi++,${LIBMIDI_VERSION})
 
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 dnl ====================================================================
 dnl you do have C++, right ?

--- a/libs/pbd/configure.ac
+++ b/libs/pbd/configure.ac
@@ -23,7 +23,7 @@ AC_SUBST(LIBPBD_RELEASE)
 
 AM_INIT_AUTOMAKE(libpbd,${LIBPBD_VERSION})
 
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 dnl Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
I'm unable to build sooperlooper with automake 1.13.1 due to obsolete AM_CONFIG_HEADER usage, this uses AC_CONFIG_HEADERS instead.
