### PR TITLE
Fix issue related to midi learn.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+- Fixed small midi learn related glitch: midi learnt CC commands could not be
+  removed or modified in preferences dialog
 - Fixed issue of loosing separate IO ports when loading a session while running
 - moved to sigc++-2.0
 

--- a/src/midi_bridge.cpp
+++ b/src/midi_bridge.cpp
@@ -332,7 +332,7 @@ MidiBridge::finish_learn(MIDI::byte chcmd, MIDI::byte param, MIDI::byte val)
 
 			// if type is n, then lets force the command to be note as well
 			if (CommandMap::instance().is_command(_learninfo.control)) {
-				if (_learninfo.type == "pc") {
+				if (_learninfo.type == "pc" || _learninfo.type == "cc") {
 					_learninfo.command = "hit";
 				}
 				else {


### PR DESCRIPTION
Should fix [this bug in the SL Forum](http://essej.net/slforum/viewtopic.php?f=15&t=3596). Learnt CC midi bindings now have the same behaviour as midi bingings created in the preferences -> midi bindings dialog.
