### PR TITLE
Use namespaced sigc::bind due to clash with std::bind

### DIFF
--- a/src/control_osc.hpp
+++ b/src/control_osc.hpp
@@ -27,7 +27,7 @@
 #include <list>
 #include <utility>
 
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 
 #include "event.hpp"
 #include "event_nonrt.hpp"

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -313,7 +313,7 @@ void Engine::set_midi_bridge (MidiBridge * bridge)
 		_midi_bridge->MidiControlEvent.connect (mem_fun(*this, &Engine::push_midi_control_event));
 		_midi_bridge->MidiSyncEvent.connect (mem_fun(*this, &Engine::push_sync_event));
 
-		ParamChanged.connect(bind (mem_fun(*_midi_bridge, &MidiBridge::parameter_changed), this));
+		ParamChanged.connect(sigc::bind(mem_fun(*_midi_bridge, &MidiBridge::parameter_changed), this));
 
 		_midi_bridge->set_output_midi_clock(_output_midi_clock);
 	}

--- a/src/gui/app_frame.hpp
+++ b/src/gui/app_frame.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 #include <sigc++/signal.h>
 #include <sigc++/connection.h>
 

--- a/src/gui/config_panel.hpp
+++ b/src/gui/config_panel.hpp
@@ -26,7 +26,7 @@
 
 #include <string>
 #include <vector>
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 
 class wxListCtrl;
 class wxSpinCtrl;

--- a/src/gui/keys_panel.hpp
+++ b/src/gui/keys_panel.hpp
@@ -26,7 +26,7 @@
 
 #include <string>
 #include <vector>
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 
 class wxListCtrl;
 

--- a/src/gui/latency_panel.cpp
+++ b/src/gui/latency_panel.cpp
@@ -150,7 +150,7 @@ void LatencyPanel::init()
 	_input_spin->set_allow_outside_bounds(false);
 	//_input_spin->SetFont (sliderFont);
 	_input_spin->set_decimal_digits(0);
-	_input_spin->value_changed.connect (bind (mem_fun (*this,  &LatencyPanel::on_spin_change), (int) ID_InputLatency));
+	_input_spin->value_changed.connect (sigc::bind(mem_fun (*this,  &LatencyPanel::on_spin_change), (int) ID_InputLatency));
 	rowsizer->Add (_input_spin, 1, wxLEFT|wxEXPAND, 10);
 
 	_output_spin = new SpinBox(this, ID_OutputLatency, 0.0f, 100000.0f, 512.0f, false, wxDefaultPosition, wxSize(200, 35));
@@ -160,7 +160,7 @@ void LatencyPanel::init()
 	_output_spin->set_allow_outside_bounds(false);
 	_output_spin->set_decimal_digits(0);
 	//_output_spin->SetFont (sliderFont);
-	_output_spin->value_changed.connect (bind (mem_fun (*this,  &LatencyPanel::on_spin_change), (int) ID_OutputLatency));
+	_output_spin->value_changed.connect (sigc::bind(mem_fun (*this,  &LatencyPanel::on_spin_change), (int) ID_OutputLatency));
 	rowsizer->Add (_output_spin, 1, wxLEFT|wxRIGHT|wxEXPAND, 10);
 	
 	

--- a/src/gui/latency_panel.hpp
+++ b/src/gui/latency_panel.hpp
@@ -26,7 +26,7 @@
 
 #include <string>
 #include <vector>
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 
 class wxListCtrl;
 

--- a/src/gui/looper_panel.cpp
+++ b/src/gui/looper_panel.cpp
@@ -212,8 +212,8 @@ LooperPanel::init()
 	slider->set_show_indicator_bar (false);
 	slider->set_scale_mode(SliderBar::ZeroGainMode);
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 	inthresh_sizer->Add (slider, 1, wxALL|wxEXPAND, 0);
 	
 	_thresh_control = slider = new SliderBar(this, ID_ThreshControl, 0.0f, 1.0f, 0.0f);
@@ -222,8 +222,8 @@ LooperPanel::init()
 	slider->set_show_indicator_bar (true);
 	slider->set_scale_mode(SliderBar::ZeroGainMode);
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 	inthresh_sizer->Add (slider, 1, wxLEFT|wxEXPAND, 3);
 	
 	colsizer->Add (inthresh_sizer, 1, wxEXPAND|wxLEFT, 5);
@@ -232,8 +232,8 @@ LooperPanel::init()
 	slider->set_units(wxT("%"));
 	slider->set_label(wxT("feedback"));
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 
 	_maininsizer->Add (slider, 1, wxEXPAND|wxTOP, 5);
 
@@ -281,8 +281,8 @@ LooperPanel::init()
 // 	slider->set_label(wxT("dry"));
 // 	slider->set_scale_mode(SliderBar::ZeroGainMode);
 // 	slider->SetFont(sliderFont);
-// 	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-// 	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+// 	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+// 	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 // 	_toppansizer->Add (slider, 1, wxEXPAND, 0);
 
 	// panners are added later
@@ -297,8 +297,8 @@ LooperPanel::init()
 	slider->set_show_indicator_bar (true);
 	slider->set_scale_mode(SliderBar::ZeroGainMode);
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 	_botpansizer->Add (slider, 1, wxEXPAND, 0);
 
 	/*
@@ -307,7 +307,7 @@ LooperPanel::init()
 	_outlatency_spin->set_label(wxT("o.lat"));
 	_outlatency_spin->set_snap_mode (SpinBox::IntegerSnap);
 	_outlatency_spin->set_allow_outside_bounds(true);
-	_outlatency_spin->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) _outlatency_spin->GetId()));
+	_outlatency_spin->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) _outlatency_spin->GetId()));
 	_outlatency_spin->SetFont(sliderFont);
 	_botpansizer->Add (_outlatency_spin, 0, wxALL, 0);
 
@@ -316,7 +316,7 @@ LooperPanel::init()
 	_inlatency_spin->set_label(wxT("i.lat"));
 	_inlatency_spin->set_snap_mode (SpinBox::IntegerSnap);
 	_inlatency_spin->set_allow_outside_bounds(true);
-	_inlatency_spin->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) _inlatency_spin->GetId()));
+	_inlatency_spin->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) _inlatency_spin->GetId()));
 	_inlatency_spin->SetFont(sliderFont);
 	_botpansizer->Add (_inlatency_spin, 0, wxALL, 0);
 	*/
@@ -361,8 +361,8 @@ LooperPanel::init()
 	_sync_check = new CheckBox(this, ID_SyncCheck, wxT("sync"), true, wxDefaultPosition, wxSize(55, 18));
 	_sync_check->SetFont(sliderFont);
 	_sync_check->SetToolTip(wxT("sync operations to quantize source"));
-	_sync_check->value_changed.connect (bind (mem_fun (*this, &LooperPanel::check_events), wxT("sync")));
-	_sync_check->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) _sync_check->GetId()));
+	_sync_check->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::check_events), wxT("sync")));
+	_sync_check->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) _sync_check->GetId()));
 	lilrowsizer->Add (_sync_check, 1, wxLEFT, 3);
 	lilcolsizer->Add (lilrowsizer, 0, wxTOP|wxEXPAND, 0);
 
@@ -370,8 +370,8 @@ LooperPanel::init()
 	_play_sync_check = new CheckBox(this, ID_PlaySyncCheck, wxT("play sync"), true, wxDefaultPosition, wxSize(55, 18));
 	_play_sync_check->SetFont(sliderFont);
 	_play_sync_check->SetToolTip(wxT("sync playback auto-triggering to quantized sync source"));
-	_play_sync_check->value_changed.connect (bind (mem_fun (*this, &LooperPanel::check_events), wxT("playback_sync")));
-	_play_sync_check->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) _play_sync_check->GetId()));
+	_play_sync_check->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::check_events), wxT("playback_sync")));
+	_play_sync_check->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) _play_sync_check->GetId()));
 	lilrowsizer->Add (_play_sync_check, 1, wxLEFT, 3);
 	lilcolsizer->Add (lilrowsizer, 0, wxTOP|wxEXPAND, 0);
 	
@@ -379,15 +379,15 @@ LooperPanel::init()
 	_play_feed_check = new CheckBox(this, ID_UseFeedbackPlayCheck, wxT("p. feedb"), true, wxDefaultPosition, wxSize(55, 18));
 	_play_feed_check->SetFont(sliderFont);
 	_play_feed_check->SetToolTip(wxT("enable feedback during playback"));
-	_play_feed_check->value_changed.connect (bind (mem_fun (*this, &LooperPanel::check_events), wxT("use_feedback_play")));
-	_play_feed_check->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) _play_feed_check->GetId()));
+	_play_feed_check->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::check_events), wxT("use_feedback_play")));
+	_play_feed_check->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) _play_feed_check->GetId()));
 	lilrowsizer->Add (_play_feed_check, 1, wxLEFT, 3);
 
 	_tempo_stretch_check = new CheckBox(this, ID_TempoStretchCheck, wxT("t. stretch"), true, wxDefaultPosition, wxSize(55, 18));
 	_tempo_stretch_check->SetFont(sliderFont);
 	_tempo_stretch_check->SetToolTip(wxT("enable automatic timestretch when tempo changes"));
-	_tempo_stretch_check->value_changed.connect (bind (mem_fun (*this, &LooperPanel::check_events), wxT("tempo_stretch")));
-	_tempo_stretch_check->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) _tempo_stretch_check->GetId()));
+	_tempo_stretch_check->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::check_events), wxT("tempo_stretch")));
+	_tempo_stretch_check->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) _tempo_stretch_check->GetId()));
 	lilrowsizer->Add (_tempo_stretch_check, 1, wxLEFT, 3);
 
 	lilcolsizer->Add (lilrowsizer, 0, wxTOP|wxEXPAND, 0);
@@ -440,8 +440,8 @@ LooperPanel::init()
 	slider->set_show_value(false);
 	slider->set_show_indicator_bar (true);
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 	rowsizer->Add (slider, 1, wxEXPAND|wxTOP|wxLEFT, 3);
 
 	// pitch control
@@ -452,8 +452,8 @@ LooperPanel::init()
 	slider->set_decimal_digits (1);
 	slider->set_snap_mode(SliderBar::IntegerSnap);
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 	rowsizer->Add (slider, 1, wxEXPAND|wxTOP|wxLEFT, 3);
 
 	// pause
@@ -476,8 +476,8 @@ LooperPanel::init()
 	slider->set_style (SliderBar::CenterStyle);
 	slider->set_decimal_digits (3);
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 	rowsizer->Add (slider, 1, wxEXPAND|wxTOP|wxLEFT, 3);
 
 	// stretch control
@@ -487,8 +487,8 @@ LooperPanel::init()
 	slider->set_style (SliderBar::CenterStyle);
 	slider->set_decimal_digits (2);
 	slider->SetFont(sliderFont);
-	slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-	slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+	slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+	slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 	rowsizer->Add (slider, 1, wxEXPAND|wxTOP|wxLEFT, 3);
 
 
@@ -498,7 +498,7 @@ LooperPanel::init()
 	_triglatency_spin->set_label(wxT("t.lat"));
 	_triglatency_spin->set_snap_mode (SpinBox::IntegerSnap);
 	_triglatency_spin->set_allow_outside_bounds(true);
-	_triglatency_spin->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) _triglatency_spin->GetId()));
+	_triglatency_spin->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) _triglatency_spin->GetId()));
 	_triglatency_spin->SetFont(sliderFont);
 	rowsizer->Add (_triglatency_spin, 0, wxALL, 0);
 	*/
@@ -555,15 +555,15 @@ LooperPanel::post_init()
 		slider->set_label(wxT("in mon"));
 		slider->set_scale_mode(SliderBar::ZeroGainMode);
 		slider->SetFont(sliderFont);
-		slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
-		slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
+		slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::slider_events), (int) slider->GetId()));
+		slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) slider->GetId()));
 		_toppansizer->Add (slider, 1, wxEXPAND, 0);
 
 		_use_main_in_check = new CheckBox(this, ID_UseMainInCheck, wxT("main in"), true, wxDefaultPosition, wxSize(65, 18));
 		_use_main_in_check->SetFont(sliderFont);
 		_use_main_in_check->SetToolTip(wxT("mix input from Main inputs"));
-		_use_main_in_check->value_changed.connect (bind (mem_fun (*this, &LooperPanel::check_events), wxT("use_common_ins")));
-		_use_main_in_check->bind_request.connect (bind (mem_fun (*this, &LooperPanel::control_bind_events), (int) _use_main_in_check->GetId()));
+		_use_main_in_check->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::check_events), wxT("use_common_ins")));
+		_use_main_in_check->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::control_bind_events), (int) _use_main_in_check->GetId()));
 		_maininsizer->Add (_use_main_in_check, 0, wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL ,0);
 		_maininsizer->Layout();
 
@@ -595,8 +595,8 @@ LooperPanel::post_init()
 		slider->set_decimal_digits (3);
 		slider->set_show_value (false);
 		slider->SetFont(sliderFont);
-		slider->value_changed.connect (bind (mem_fun (*this, &LooperPanel::pan_events), (int) i));
-		slider->bind_request.connect (bind (mem_fun (*this, &LooperPanel::pan_bind_events), (int) i));
+		slider->value_changed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pan_events), (int) i));
+		slider->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::pan_bind_events), (int) i));
 
 		if (!_has_discrete_io) {
 			_toppansizer->Add (slider, 1, (i==0) ? wxEXPAND : wxEXPAND|wxLEFT, 2);
@@ -652,83 +652,83 @@ LooperPanel::set_index(int ind)
 void
 LooperPanel::bind_events()
 {
-	_undo_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("undo"))));
-	_undo_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("undo"))));
-	_undo_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("undo"))));
+	_undo_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("undo"))));
+	_undo_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("undo"))));
+	_undo_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("undo"))));
 
-	_redo_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("redo"))));
-	_redo_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("redo"))));
-	_redo_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("redo"))));
+	_redo_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("redo"))));
+	_redo_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("redo"))));
+	_redo_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("redo"))));
 
-	_record_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("record"))));
-	_record_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("record"))));
-	_record_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("record"))));
+	_record_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("record"))));
+	_record_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("record"))));
+	_record_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("record"))));
 
-	_overdub_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("overdub"))));
-	_overdub_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("overdub"))));
-	_overdub_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("overdub"))));
+	_overdub_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("overdub"))));
+	_overdub_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("overdub"))));
+	_overdub_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("overdub"))));
 
-	_multiply_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("multiply"))));
-	_multiply_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("multiply"))));
-	_multiply_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("multiply"))));
+	_multiply_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("multiply"))));
+	_multiply_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("multiply"))));
+	_multiply_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("multiply"))));
 
-	_replace_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("replace"))));
-	_replace_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("replace"))));
-	_replace_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("replace"))));
+	_replace_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("replace"))));
+	_replace_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("replace"))));
+	_replace_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("replace"))));
 
-	_insert_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("insert"))));
-	_insert_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("insert"))));
-	_insert_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("insert"))));
+	_insert_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("insert"))));
+	_insert_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("insert"))));
+	_insert_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("insert"))));
 
-	_once_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("oneshot"))));
-	_once_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("oneshot"))));
-	_once_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("oneshot"))));
+	_once_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("oneshot"))));
+	_once_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("oneshot"))));
+	_once_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("oneshot"))));
 
-	_trig_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("trigger"))));
-	_trig_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("trigger"))));
-	_trig_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("trigger"))));
+	_trig_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("trigger"))));
+	_trig_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("trigger"))));
+	_trig_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("trigger"))));
 
 	_delay_button->pressed.connect (mem_fun (*this, &LooperPanel::delay_button_press_event));
 	_delay_button->released.connect (mem_fun (*this, &LooperPanel::delay_button_release_event));
-	_delay_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("delay_trigger"))));
+	_delay_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("delay_trigger"))));
 
-	_reverse_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("reverse"))));
-	_reverse_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("reverse"))));
-	_reverse_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("reverse"))));
+	_reverse_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("reverse"))));
+	_reverse_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("reverse"))));
+	_reverse_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("reverse"))));
 
-	_substitute_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("substitute"))));
-	_substitute_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("substitute"))));
-	_substitute_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("substitute"))));
+	_substitute_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("substitute"))));
+	_substitute_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("substitute"))));
+	_substitute_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("substitute"))));
 	
-	_mute_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("mute"))));
-	_mute_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("mute"))));
-	_mute_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("mute"))));
+	_mute_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("mute"))));
+	_mute_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("mute"))));
+	_mute_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("mute"))));
 
-	_pause_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("pause"))));
-	_pause_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("pause"))));
-	_pause_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("pause"))));
+	_pause_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("pause"))));
+	_pause_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("pause"))));
+	_pause_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("pause"))));
 
-	_solo_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("solo"))));
-	_solo_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("solo"))));
-	_solo_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("solo"))));
+	_solo_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("solo"))));
+	_solo_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("solo"))));
+	_solo_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("solo"))));
 
-	_halfx_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::rate_button_event), 0.5f));
-	_halfx_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::rate_bind_events), 0.5f));
-	_1x_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::rate_button_event), 1.0f));
-	_1x_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::rate_bind_events), 1.0f));
-	_2x_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::rate_button_event), 2.0f));
-	_2x_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::rate_bind_events), 2.0f));
+	_halfx_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::rate_button_event), 0.5f));
+	_halfx_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::rate_bind_events), 0.5f));
+	_1x_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::rate_button_event), 1.0f));
+	_1x_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::rate_bind_events), 1.0f));
+	_2x_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::rate_button_event), 2.0f));
+	_2x_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::rate_bind_events), 2.0f));
 
-	_scratch_button->pressed.connect (bind (mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("scratch"))));
-	_scratch_button->released.connect (bind (mem_fun (*this, &LooperPanel::released_events), wxString(wxT("scratch"))));
-	_scratch_button->bind_request.connect (bind (mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("scratch"))));
+	_scratch_button->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::pressed_events), wxString(wxT("scratch"))));
+	_scratch_button->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::released_events), wxString(wxT("scratch"))));
+	_scratch_button->bind_request.connect (sigc::bind(mem_fun (*this, &LooperPanel::button_bind_events), wxString(wxT("scratch"))));
 
-	_save_button->clicked.connect (bind (mem_fun (*this, &LooperPanel::clicked_events), wxString(wxT("save"))));
-	_load_button->clicked.connect (bind (mem_fun (*this, &LooperPanel::clicked_events), wxString(wxT("load"))));
+	_save_button->clicked.connect (sigc::bind(mem_fun (*this, &LooperPanel::clicked_events), wxString(wxT("save"))));
+	_load_button->clicked.connect (sigc::bind(mem_fun (*this, &LooperPanel::clicked_events), wxString(wxT("load"))));
 
 
-	_scratch_control->pressed.connect (bind (mem_fun (*this, &LooperPanel::scratch_events), wxString(wxT("scratch_press"))));
-	_scratch_control->released.connect (bind (mem_fun (*this, &LooperPanel::scratch_events), wxString(wxT("scratch_release"))));
+	_scratch_control->pressed.connect (sigc::bind(mem_fun (*this, &LooperPanel::scratch_events), wxString(wxT("scratch_press"))));
+	_scratch_control->released.connect (sigc::bind(mem_fun (*this, &LooperPanel::scratch_events), wxString(wxT("scratch_release"))));
 
 	
 	_loop_control->MidiBindingChanged.connect (mem_fun (*this, &LooperPanel::got_binding_changed));

--- a/src/gui/main_panel.cpp
+++ b/src/gui/main_panel.cpp
@@ -217,7 +217,7 @@ MainPanel::init()
 	_sync_choice->set_label (wxT("sync to"));
 	_sync_choice->SetFont (sliderFont);
 	_sync_choice->value_changed.connect (mem_fun (*this,  &MainPanel::on_syncto_change));
-	_sync_choice->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("sync")));
+	_sync_choice->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("sync")));
 	
 	rowsizer->Add (_sync_choice, 0, wxALL|wxEXPAND, 2);
 	
@@ -228,7 +228,7 @@ MainPanel::init()
 	_tempo_bar->set_allow_outside_bounds(true);
 	_tempo_bar->SetFont (sliderFont);
 	_tempo_bar->value_changed.connect (mem_fun (*this,  &MainPanel::on_tempo_change));
-	_tempo_bar->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("tempo")));
+	_tempo_bar->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("tempo")));
 	rowsizer->Add (_tempo_bar, 0, wxALL|wxEXPAND, 2);
 
  	_taptempo_button = new PixButton(_top_panel, ID_TapTempoButton, true);
@@ -239,7 +239,7 @@ MainPanel::init()
 	_taptempo_button->set_active_bitmap (wxBitmap(tap_tempo_active));
 	_taptempo_button->pressed.connect (mem_fun (*this, &MainPanel::on_taptempo_press));
 	_taptempo_button->released.connect (mem_fun (*this, &MainPanel::on_taptempo_release));
-	_taptempo_button->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("taptempo")));
+	_taptempo_button->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("taptempo")));
  	rowsizer->Add (_taptempo_button, 0, wxALL|wxEXPAND, 2);
 	
 
@@ -250,7 +250,7 @@ MainPanel::init()
 	_eighth_cycle_bar->set_allow_outside_bounds(true);
 	_eighth_cycle_bar->SetFont (sliderFont);
 	_eighth_cycle_bar->value_changed.connect (mem_fun (*this,  &MainPanel::on_eighth_change));
-	_eighth_cycle_bar->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("eighth")));
+	_eighth_cycle_bar->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("eighth")));
 	rowsizer->Add (_eighth_cycle_bar, 0, wxALL|wxEXPAND, 2);
 	
 
@@ -258,7 +258,7 @@ MainPanel::init()
 	_quantize_choice->SetFont (sliderFont);
 	_quantize_choice->set_label (wxT("quantize"));
 	_quantize_choice->value_changed.connect (mem_fun (*this,  &MainPanel::on_quantize_change));
-	_quantize_choice->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("quantize")));
+	_quantize_choice->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("quantize")));
 	_quantize_choice->append_choice (wxT("off"), 0);
 	_quantize_choice->append_choice (wxT("cycle"), 1);
 	_quantize_choice->append_choice (wxT("8th"), 2);
@@ -269,21 +269,21 @@ MainPanel::init()
 	_mute_quant_check->SetFont(sliderFont);
 	_mute_quant_check->SetToolTip(wxT("quantize mute operations"));
 	_mute_quant_check->value_changed.connect (mem_fun (*this, &MainPanel::on_mute_quant_check));
-	_mute_quant_check->bind_request.connect (bind (mem_fun (*this, &MainPanel::on_bind_request), wxT("mute_quantized")));
+	_mute_quant_check->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("mute_quantized")));
 	rowsizer->Add (_mute_quant_check, 0, wxALL|wxEXPAND, 2);
 
 	_odub_quant_check = new CheckBox(_top_panel, ID_OdubQuantCheck, wxT("odub quant"), true, wxDefaultPosition, wxSize(90, 18));
 	_odub_quant_check->SetFont(sliderFont);
 	_odub_quant_check->SetToolTip(wxT("quantize overdub operations"));
 	_odub_quant_check->value_changed.connect (mem_fun (*this, &MainPanel::on_odub_quant_check));
-	_odub_quant_check->bind_request.connect (bind (mem_fun (*this, &MainPanel::on_bind_request), wxT("overdub_quantized")));
+	_odub_quant_check->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("overdub_quantized")));
 	rowsizer->Add (_odub_quant_check, 0, wxALL|wxEXPAND, 2);
 
 	_repl_quant_check = new CheckBox(_top_panel, ID_ReplQuantCheck, wxT("repl quant"), true, wxDefaultPosition, wxSize(90, 18));
 	_repl_quant_check->SetFont(sliderFont);
 	_repl_quant_check->SetToolTip(wxT("quantize replace and substitute operations"));
 	_repl_quant_check->value_changed.connect (mem_fun (*this, &MainPanel::on_repl_quant_check));
-	_repl_quant_check->bind_request.connect (bind (mem_fun (*this, &MainPanel::on_bind_request), wxT("replace_quantized")));
+	_repl_quant_check->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("replace_quantized")));
 	rowsizer->Add (_repl_quant_check, 0, wxALL|wxEXPAND, 2);
 
 
@@ -305,7 +305,7 @@ MainPanel::init()
 	_xfade_bar->set_decimal_digits (0);
 	_xfade_bar->SetFont (sliderFont);
 	_xfade_bar->value_changed.connect (mem_fun (*this,  &MainPanel::on_xfade_change));
-	_xfade_bar->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("fade_samples")));
+	_xfade_bar->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("fade_samples")));
 	rowsizer->Add (_xfade_bar, 0, wxALL|wxEXPAND, 2);
 
 	_common_ingain_bar = new SliderBar(_top_panel, ID_InGainControl, 0.0f, 1.0f, 1.0f, true, wxDefaultPosition, wxSize(132,20));
@@ -315,7 +315,7 @@ MainPanel::init()
 	_common_ingain_bar->set_show_indicator_bar(true);
 	_common_ingain_bar->SetFont(sliderFont);
 	_common_ingain_bar->value_changed.connect (mem_fun (*this, &MainPanel::on_ingain_change));
-	_common_ingain_bar->bind_request.connect (bind (mem_fun (*this, &MainPanel::on_bind_request), wxT("input_gain")));
+	_common_ingain_bar->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("input_gain")));
 	rowsizer->Add (_common_ingain_bar, 0, wxALL|wxEXPAND, 2);
 	
 	_common_dry_bar = new SliderBar(_top_panel, ID_DryControl, 0.0f, 1.0f, 1.0f, true, wxDefaultPosition, wxSize(132,20));
@@ -325,7 +325,7 @@ MainPanel::init()
 	_common_dry_bar->set_show_indicator_bar(true);
 	_common_dry_bar->SetFont(sliderFont);
 	_common_dry_bar->value_changed.connect (mem_fun (*this, &MainPanel::on_dry_change));
-	_common_dry_bar->bind_request.connect (bind (mem_fun (*this, &MainPanel::on_bind_request), wxT("dry")));
+	_common_dry_bar->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("dry")));
 	rowsizer->Add (_common_dry_bar, 0, wxALL|wxEXPAND, 2);
 
 	_common_wet_bar = new SliderBar(_top_panel, ID_WetControl, 0.0f, 1.0f, 1.0f, true, wxDefaultPosition, wxSize(132,20));
@@ -335,7 +335,7 @@ MainPanel::init()
 	_common_wet_bar->set_show_indicator_bar(true);
 	_common_wet_bar->SetFont(sliderFont);
 	_common_wet_bar->value_changed.connect (mem_fun (*this, &MainPanel::on_wet_change));
-	_common_wet_bar->bind_request.connect (bind (mem_fun (*this, &MainPanel::on_bind_request), wxT("wet")));
+	_common_wet_bar->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("wet")));
 	rowsizer->Add (_common_wet_bar, 0, wxALL|wxEXPAND, 2);
 	
 
@@ -343,13 +343,13 @@ MainPanel::init()
 	_round_check = new CheckBox (_top_panel, ID_RoundCheck, wxT("round"), true, wxDefaultPosition, wxSize(60, 20));
 	_round_check->SetFont (sliderFont);
 	_round_check->value_changed.connect (mem_fun (*this, &MainPanel::on_round_check));
-	_round_check->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("round")));
+	_round_check->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("round")));
 	rowsizer->Add (_round_check, 0, wxALL|wxEXPAND, 2);
 
 	_relsync_check = new CheckBox (_top_panel, ID_RelSyncCheck, wxT("rel sync"), true, wxDefaultPosition, wxSize(75, 20));
 	_relsync_check->SetFont (sliderFont);
 	_relsync_check->value_changed.connect (mem_fun (*this, &MainPanel::on_relsync_check));
-	_relsync_check->bind_request.connect (bind (mem_fun (*this,  &MainPanel::on_bind_request), wxT("relative_sync")));
+	_relsync_check->bind_request.connect (sigc::bind(mem_fun (*this,  &MainPanel::on_bind_request), wxT("relative_sync")));
 	rowsizer->Add (_relsync_check, 0, wxALL|wxEXPAND, 2);
 	
 
@@ -357,7 +357,7 @@ MainPanel::init()
 	_smart_eighths_check->SetFont(sliderFont);
 	_smart_eighths_check->SetToolTip(wxT("auto adjust 8ths per cycle with tempo"));
 	_smart_eighths_check->value_changed.connect (mem_fun (*this, &MainPanel::on_smart_eighths_check));
-	_smart_eighths_check->bind_request.connect (bind (mem_fun (*this, &MainPanel::on_bind_request), wxT("smart_eighths")));
+	_smart_eighths_check->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("smart_eighths")));
 	rowsizer->Add (_smart_eighths_check, 0, wxALL|wxEXPAND, 2);
 
 
@@ -379,7 +379,7 @@ MainPanel::init()
 
 	// todo request how many loopers to construct based on connection
 	_loop_connect_connection = _loop_control->LooperConnected.connect (mem_fun (*this, &MainPanel::init_loopers));
-	_loop_disconnect_connection = _loop_control->Disconnected.connect (bind (mem_fun (*this, &MainPanel::init_loopers), 0));
+	_loop_disconnect_connection = _loop_control->Disconnected.connect (sigc::bind(mem_fun (*this, &MainPanel::init_loopers), 0));
 	_loop_update_connection = _loop_control->NewDataReady.connect (mem_fun (*this, &MainPanel::osc_data_ready));
 
 
@@ -1112,67 +1112,67 @@ MainPanel::process_key_event (wxKeyEvent &ev)
 void MainPanel::intialize_keybindings ()
 {
 	
-	_keyboard->add_action ("record", bind (mem_fun (*this, &MainPanel::command_action), wxT("record")));
-	_keyboard->add_action ("overdub", bind (mem_fun (*this, &MainPanel::command_action), wxT("overdub")));
-	_keyboard->add_action ("multiply", bind (mem_fun (*this, &MainPanel::command_action), wxT("multiply")));
-	_keyboard->add_action ("insert", bind (mem_fun (*this, &MainPanel::command_action), wxT("insert")));
-	_keyboard->add_action ("replace", bind (mem_fun (*this, &MainPanel::command_action), wxT("replace")));
-	_keyboard->add_action ("reverse", bind (mem_fun (*this, &MainPanel::command_action), wxT("reverse")));
-	_keyboard->add_action ("scratch", bind (mem_fun (*this, &MainPanel::command_action), wxT("scratch")));
-	_keyboard->add_action ("substitute", bind (mem_fun (*this, &MainPanel::command_action), wxT("substitute")));
-	_keyboard->add_action ("mute", bind (mem_fun (*this, &MainPanel::command_action), wxT("mute")));
-	_keyboard->add_action ("mute_on", bind (mem_fun (*this, &MainPanel::command_action), wxT("mute_on")));
-	_keyboard->add_action ("mute_off", bind (mem_fun (*this, &MainPanel::command_action), wxT("mute_off")));
-	_keyboard->add_action ("mute_trigger", bind (mem_fun (*this, &MainPanel::command_action), wxT("mute_trigger")));
-	_keyboard->add_action ("undo", bind (mem_fun (*this, &MainPanel::command_action), wxT("undo")));
-	_keyboard->add_action ("redo", bind (mem_fun (*this, &MainPanel::command_action), wxT("redo")));	
-	_keyboard->add_action ("undo_all", bind (mem_fun (*this, &MainPanel::command_action), wxT("undo_all")));
-	_keyboard->add_action ("redo_all", bind (mem_fun (*this, &MainPanel::command_action), wxT("redo_all")));	
-	_keyboard->add_action ("oneshot", bind (mem_fun (*this, &MainPanel::command_action), wxT("oneshot")));
-	_keyboard->add_action ("trigger", bind (mem_fun (*this, &MainPanel::command_action), wxT("trigger")));
-	_keyboard->add_action ("pause", bind (mem_fun (*this, &MainPanel::command_action), wxT("pause")));
-	_keyboard->add_action ("pause_on", bind (mem_fun (*this, &MainPanel::command_action), wxT("pause_on")));
-	_keyboard->add_action ("pause_off", bind (mem_fun (*this, &MainPanel::command_action), wxT("pause_off")));
-	_keyboard->add_action ("solo", bind (mem_fun (*this, &MainPanel::command_action), wxT("solo")));
-	_keyboard->add_action ("solo_prev", bind (mem_fun (*this, &MainPanel::command_action), wxT("solo_prev")));
-	_keyboard->add_action ("solo_next", bind (mem_fun (*this, &MainPanel::command_action), wxT("solo_next")));
-	_keyboard->add_action ("record_solo", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_solo")));
-	_keyboard->add_action ("record_solo_prev", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_solo_prev")));
-	_keyboard->add_action ("record_solo_next", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_solo_next")));
-	_keyboard->add_action ("set_sync_pos", bind (mem_fun (*this, &MainPanel::command_action), wxT("set_sync_pos")));
-	_keyboard->add_action ("reset_sync_pos", bind (mem_fun (*this, &MainPanel::command_action), wxT("reset_sync_pos")));
-	_keyboard->add_action ("record_or_overdub", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub")));
-	_keyboard->add_action ("record_exclusive", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_exclusive")));
-	_keyboard->add_action ("record_exclusive_next", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_exclusive_next")));
-	_keyboard->add_action ("record_exclusive_prev", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_exclusive_prev")));	
-	_keyboard->add_action ("record_or_overdub_excl", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_excl")));
-	_keyboard->add_action ("record_or_overdub_excl_next", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_excl_next")));
-	_keyboard->add_action ("record_or_overdub_excl_prev", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_excl_prev")));
-	_keyboard->add_action ("record_or_overdub_solo", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_solo")));
-	_keyboard->add_action ("record_or_overdub_solo_next", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_solo_next")));
-	_keyboard->add_action ("record_or_overdub_solo_prev", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_solo_prev")));
-	_keyboard->add_action ("record_overdub_end_solo", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_overdub_end_solo")));
-	_keyboard->add_action ("record_overdub_end_solo_trig", bind (mem_fun (*this, &MainPanel::command_action), wxT("record_overdub_end_solo_trig")));
+	_keyboard->add_action ("record", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record")));
+	_keyboard->add_action ("overdub", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("overdub")));
+	_keyboard->add_action ("multiply", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("multiply")));
+	_keyboard->add_action ("insert", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("insert")));
+	_keyboard->add_action ("replace", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("replace")));
+	_keyboard->add_action ("reverse", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("reverse")));
+	_keyboard->add_action ("scratch", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("scratch")));
+	_keyboard->add_action ("substitute", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("substitute")));
+	_keyboard->add_action ("mute", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("mute")));
+	_keyboard->add_action ("mute_on", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("mute_on")));
+	_keyboard->add_action ("mute_off", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("mute_off")));
+	_keyboard->add_action ("mute_trigger", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("mute_trigger")));
+	_keyboard->add_action ("undo", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("undo")));
+	_keyboard->add_action ("redo", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("redo")));	
+	_keyboard->add_action ("undo_all", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("undo_all")));
+	_keyboard->add_action ("redo_all", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("redo_all")));	
+	_keyboard->add_action ("oneshot", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("oneshot")));
+	_keyboard->add_action ("trigger", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("trigger")));
+	_keyboard->add_action ("pause", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("pause")));
+	_keyboard->add_action ("pause_on", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("pause_on")));
+	_keyboard->add_action ("pause_off", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("pause_off")));
+	_keyboard->add_action ("solo", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("solo")));
+	_keyboard->add_action ("solo_prev", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("solo_prev")));
+	_keyboard->add_action ("solo_next", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("solo_next")));
+	_keyboard->add_action ("record_solo", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_solo")));
+	_keyboard->add_action ("record_solo_prev", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_solo_prev")));
+	_keyboard->add_action ("record_solo_next", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_solo_next")));
+	_keyboard->add_action ("set_sync_pos", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("set_sync_pos")));
+	_keyboard->add_action ("reset_sync_pos", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("reset_sync_pos")));
+	_keyboard->add_action ("record_or_overdub", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub")));
+	_keyboard->add_action ("record_exclusive", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_exclusive")));
+	_keyboard->add_action ("record_exclusive_next", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_exclusive_next")));
+	_keyboard->add_action ("record_exclusive_prev", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_exclusive_prev")));	
+	_keyboard->add_action ("record_or_overdub_excl", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_excl")));
+	_keyboard->add_action ("record_or_overdub_excl_next", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_excl_next")));
+	_keyboard->add_action ("record_or_overdub_excl_prev", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_excl_prev")));
+	_keyboard->add_action ("record_or_overdub_solo", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_solo")));
+	_keyboard->add_action ("record_or_overdub_solo_next", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_solo_next")));
+	_keyboard->add_action ("record_or_overdub_solo_prev", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_or_overdub_solo_prev")));
+	_keyboard->add_action ("record_overdub_end_solo", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_overdub_end_solo")));
+	_keyboard->add_action ("record_overdub_end_solo_trig", sigc::bind(mem_fun (*this, &MainPanel::command_action), wxT("record_overdub_end_solo_trig")));
 
     
-	_keyboard->add_action ("delay", bind (mem_fun (*this, &MainPanel::misc_action), wxT("delay")));
-	_keyboard->add_action ("taptempo", bind (mem_fun (*this, &MainPanel::misc_action), wxT("taptempo")));
-	_keyboard->add_action ("load", bind (mem_fun (*this, &MainPanel::misc_action), wxT("load")));
-	_keyboard->add_action ("save", bind (mem_fun (*this, &MainPanel::misc_action), wxT("save")));
-	_keyboard->add_action ("cancel_midi_learn", bind (mem_fun (*this, &MainPanel::misc_action), wxT("cancel_learn")));
+	_keyboard->add_action ("delay", sigc::bind(mem_fun (*this, &MainPanel::misc_action), wxT("delay")));
+	_keyboard->add_action ("taptempo", sigc::bind(mem_fun (*this, &MainPanel::misc_action), wxT("taptempo")));
+	_keyboard->add_action ("load", sigc::bind(mem_fun (*this, &MainPanel::misc_action), wxT("load")));
+	_keyboard->add_action ("save", sigc::bind(mem_fun (*this, &MainPanel::misc_action), wxT("save")));
+	_keyboard->add_action ("cancel_midi_learn", sigc::bind(mem_fun (*this, &MainPanel::misc_action), wxT("cancel_learn")));
 
-	_keyboard->add_action ("select_prev_loop", bind (mem_fun (*this, &MainPanel::select_loop_action), -2));
-	_keyboard->add_action ("select_next_loop", bind (mem_fun (*this, &MainPanel::select_loop_action), -1));
-	_keyboard->add_action ("select_loop_1", bind (mem_fun (*this, &MainPanel::select_loop_action), 1));
-	_keyboard->add_action ("select_loop_2", bind (mem_fun (*this, &MainPanel::select_loop_action), 2));
-	_keyboard->add_action ("select_loop_3", bind (mem_fun (*this, &MainPanel::select_loop_action), 3));
-	_keyboard->add_action ("select_loop_4", bind (mem_fun (*this, &MainPanel::select_loop_action), 4));
-	_keyboard->add_action ("select_loop_5", bind (mem_fun (*this, &MainPanel::select_loop_action), 5));
-	_keyboard->add_action ("select_loop_6", bind (mem_fun (*this, &MainPanel::select_loop_action), 6));
-	_keyboard->add_action ("select_loop_7", bind (mem_fun (*this, &MainPanel::select_loop_action), 7));
-	_keyboard->add_action ("select_loop_8", bind (mem_fun (*this, &MainPanel::select_loop_action), 8));
-	_keyboard->add_action ("select_loop_9", bind (mem_fun (*this, &MainPanel::select_loop_action), 9));
-	_keyboard->add_action ("select_loop_all", bind (mem_fun (*this, &MainPanel::select_loop_action), 0));
+	_keyboard->add_action ("select_prev_loop", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), -2));
+	_keyboard->add_action ("select_next_loop", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), -1));
+	_keyboard->add_action ("select_loop_1", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 1));
+	_keyboard->add_action ("select_loop_2", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 2));
+	_keyboard->add_action ("select_loop_3", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 3));
+	_keyboard->add_action ("select_loop_4", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 4));
+	_keyboard->add_action ("select_loop_5", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 5));
+	_keyboard->add_action ("select_loop_6", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 6));
+	_keyboard->add_action ("select_loop_7", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 7));
+	_keyboard->add_action ("select_loop_8", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 8));
+	_keyboard->add_action ("select_loop_9", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 9));
+	_keyboard->add_action ("select_loop_all", sigc::bind(mem_fun (*this, &MainPanel::select_loop_action), 0));
 
 	
 	// these are the defaults... they get overridden by rc file

--- a/src/gui/main_panel.hpp
+++ b/src/gui/main_panel.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 #include <sigc++/signal.h>
 #include <sigc++/connection.h>
 

--- a/src/gui/midi_bind_panel.hpp
+++ b/src/gui/midi_bind_panel.hpp
@@ -26,7 +26,7 @@
 
 #include <string>
 #include <vector>
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 #include <list>
 
 #include <midi_bind.hpp>

--- a/src/gui/prefs_dialog.hpp
+++ b/src/gui/prefs_dialog.hpp
@@ -26,7 +26,7 @@
 
 #include <string>
 #include <vector>
-#include <sigc++/object.h>
+#include <sigc++/trackable.h>
 
 class wxListCtrl;
 class wxSpinCtrl;


### PR DESCRIPTION
This fixes some issues people have been having with compiling on systems where std::bind is declared. It also fixes the sigc++ trackable imports for the latest version of sigc++.