### PR TITLE
Add Travis CI automated build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+sudo: required
+dist: trusty
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - autopoint
+      - g++-5
+      - libjack-jackd2-dev
+      - liblo-dev
+      - librubberband-dev
+      - libsamplerate0-dev
+      - libsigc++-2.0-dev
+      - libsndfile1-dev
+      - libwxgtk2.8-dev
+env:
+  - COMPILER=g++-5
+before_script:
+  - $COMPILER --version
+  - ./autogen.sh
+  - CPPFLAGS=-std=c++11 ./configure
+script:
+  - make


### PR DESCRIPTION
Hi @essej !

This PR adds support for Travis CI automated builds, which I've used it to help root-causing build issues on the Archlinux package (cf. #6 ) and toy with SL's codebase.

Example (successful) build: https://travis-ci.org/virtualtam/sooperlooper/builds/135958235

Let me know if you're interested in enabling this feature ;-)

_Note: this requires authenticating to https://travis-ci.org/ (free for OpenSource projects)_

Steps:
- add Ubuntu Toolchain PPA
- install recent packages (i.e. with decent C++11 support)
- pre-build:    autogen, configure
- build:        make
- post-build:   N/A

Resources:
- https://docs.travis-ci.com/user/languages/cpp/
- https://docs.travis-ci.com/user/apt/
- https://docs.travis-ci.com/user/environment-variables/
- http://genbattle.bitbucket.org/blog/2016/01/17/c++-travis-ci/
- https://jonasw.de/blog/2015/07/22/develop/cplusplus14-on-travis-with-cmake/
- http://stackoverflow.com/questions/29312015/building-with-more-than-one-version-of-a-compiler
