### PR TITLE
fix build with ncurses > 6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -216,7 +216,7 @@ then
     dnl curses
     AC_CHECK_LIB(ncurses,initscr,have_ncurses=yes,[AC_MSG_WARN([******** you don't have the ncurses library correctly installed])])
 
-    NCURSES_LIBS=-lncurses
+    NCURSES_LIBS="-lncurses -ltinfo"
     AC_SUBST(NCURSES_LIBS)
 
     dnl sigc++


### PR DESCRIPTION
When trying to build sooperlooper on Arch Linux with ncurses 6.0, this happens:

    /usr/bin/ld: slconsole.o: undefined reference to symbol 'wtimeout'
    /usr/lib/libtinfo.so.6: error adding symbols: DSO missing from command line
    collect2: error: ld returned 1 exit status

This patch fixes the build.