### PR TITLE
fix pos font size

### DIFF
--- a/src/gui/time_panel.cpp
+++ b/src/gui/time_panel.cpp
@@ -78,7 +78,7 @@ TimePanel::init()
 	_pos_color.Set(244, 255, 158);
 	_pos_str = wxT("00:00.00");
 	_pos_font.SetPointSize(10);
-	normalize_font_size(_pos_font, 110, 40, wxT("00:00.00"));
+	normalize_font_size(_pos_font, 110, 30, wxT("00:00.00"));
 
        	_pos_bm = new wxBitmap(110,25); 
 	_posdc.SelectObject(*_pos_bm);


### PR DESCRIPTION
The position timer font is slightly too large for its widget, this seems to be a better fit and is in line with the status display.