### PR TITLE
Typos fixes

### DIFF
--- a/libs/midi++/midiparser.cc
+++ b/libs/midi++/midiparser.cc
@@ -100,7 +100,7 @@ Parser::midi_event_type_name (eventType t)
 		return "active sense";
 	  
 	default:
-		return "unknow MIDI event type";
+		return "unknown MIDI event type";
 	}
 };
 

--- a/src/gui/keyboard_target.cpp
+++ b/src/gui/keyboard_target.cpp
@@ -408,7 +408,7 @@ KeyboardTarget::load_bindings (const XMLNode& node)
 		action = (*niter)->property ("action");
 
 		if (!keys || !action) {
-			cerr << "misformed binding node - ignored" << endl;
+			cerr << "malformed binding node - ignored" << endl;
 			continue;
 		}
 


### PR DESCRIPTION
Those 2 are coming from the debian-multimedia team and more precisely, [https://salsa.debian.org/multimedia-team/sooperlooper/blob/master/debian/patches/01-spelling_error.patch](from Jaromír Mikeš). You might want to have a look to [other patches from the Debian package](https://salsa.debian.org/multimedia-team/sooperlooper/tree/master/debian/patches) maybe.

HTH