### PR TITLE
Fix for tap_tempo after loading session with non empty loops as sync source

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -2603,7 +2603,9 @@ Engine::generate_sync (nframes_t offset, nframes_t nframes)
 			if (_quarter_note_frames > 0.0) {
 				nframes_t currpos  = (nframes_t) (_rt_instances[_sync_source-1]->get_control_value(Event::LoopPosition) * _driver->get_samplerate());
 				nframes_t loopframes = (nframes_t) (_rt_instances[_sync_source-1]->get_control_value(Event::LoopLength) * _driver->get_samplerate());
-				if (loopframes > 0) {
+				int inst_stt = (int)(_rt_instances[_sync_source-1]->get_control_value(Event::State));
+				bool inst_paused = (inst_stt == LooperStateOff || inst_stt == LooperStatePaused || inst_stt == LooperStateOffMuted);
+				if ((loopframes > 0) && !inst_paused) {
 					nframes_t testval = (((currpos + nframes) % loopframes) % (nframes_t)_quarter_note_frames);
 					
 					if (testval <= nframes || testval == 0) {


### PR DESCRIPTION
If you loaded a session with a paused, non-zero length loop as sync source, the Engine::generate_sync() was setting _beat_occurred at every entry, causing a constant stream of tap_tempo messages to all the registered clients.
To reproduce the issue, open slgui, load a previously saved session with a non-zero length loop as sync source and see how the TAP widget is constantly lighted. 