### PR TITLE
remove SetVirtualSizeHints (deprecated since wxWidgets 2.9), and fix preferences combo box size (for some systems)

### DIFF
--- a/src/gui/check_box.cpp
+++ b/src/gui/check_box.cpp
@@ -91,7 +91,6 @@ CheckBox::CheckBox(wxWindow * parent, wxWindowID id, const wxString & label, boo
 	
 	int w,h;
 	GetTextExtent(_label_str, &w, &h);
-	SetVirtualSizeHints (6 + _boxsize + w, max(_boxsize, h));
 	SetVirtualSize (6 + _boxsize + w, max(_boxsize, h));
 
 	update_size();
@@ -134,7 +133,6 @@ CheckBox::set_label (const wxString & label)
 	GetTextExtent(_label_str, &w, &h);
 
 	SetVirtualSize (6 + _boxsize + w, max(_boxsize, h));
-	SetVirtualSizeHints (6 + _boxsize + w, max(_boxsize, h));
 	Refresh(false);	
 }
 

--- a/src/gui/main_panel.cpp
+++ b/src/gui/main_panel.cpp
@@ -468,7 +468,7 @@ MainPanel::init_loopers (int count)
  	if (!_looper_panels.empty()) {
  		wxSize bestsz = _looper_panels[0]->GetBestSize();
 		//cerr << "best w: " << bestsz.GetWidth() << endl;
- 		_scroller->SetVirtualSizeHints (bestsz.GetWidth(), -1);
+ 		_scroller->SetMinClientSize (bestsz);
 		_topsizer->Layout();
 // 		_topsizer->Fit(this);
 // 		_topsizer->SetSizeHints(this);

--- a/src/gui/midi_bind_panel.cpp
+++ b/src/gui/midi_bind_panel.cpp
@@ -200,7 +200,8 @@ void MidiBindPanel::init()
 	wxStaticText * staticText;
 	//colsizer->Add (staticText, 0, wxALL|wxALIGN_CENTRE, 2);
 
-	_control_combo = new wxChoice(_edit_panel, ID_ControlCombo,  wxDefaultPosition, wxSize(100, -1), 0, 0);
+	_control_combo = new wxChoice(_edit_panel, ID_ControlCombo,  wxDefaultPosition, wxDefaultSize, 0, 0);
+	_control_combo->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 	//_control_combo->SetToolTip(wxT("Choose control or command"));
 	populate_controls();
 	//_control_combo->SetSelection(0);
@@ -252,7 +253,7 @@ void MidiBindPanel::init()
 	_chan_spin->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 	rowsizer->Add (_chan_spin, 0, wxALL|wxALIGN_CENTRE_VERTICAL, 2);
 	
-	_type_combo = new wxChoice(_edit_panel, ID_TypeCombo,  wxDefaultPosition, wxSize(100, -1), 0, 0);
+	_type_combo = new wxChoice(_edit_panel, ID_TypeCombo,  wxDefaultPosition, wxDefaultSize, 0, 0);
 	_type_combo->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 	//_control_combo->SetToolTip(wxT("Choose control or command"));
 	_type_combo->Append (NoteString);


### PR DESCRIPTION
see http://essej.net/slforum/viewtopic.php?f=20&t=5062

I had to remove the deprecated SetVirtualSizeHints to get sooperlooper to compile with wxwidgets 3.1.5-2