### PR TITLE
trigger fit so no garbled window on Debian 11 KDE

### DIFF
--- a/src/gui/latency_panel.cpp
+++ b/src/gui/latency_panel.cpp
@@ -203,7 +203,7 @@ void LatencyPanel::init()
 	
 	this->SetAutoLayout( true );     // tell dialog to use sizer
 	this->SetSizer( topsizer );      // actually set the sizer
-	//topsizer->Fit( this );            // set size to minimum size as calculated by the sizer
+	topsizer->Fit( this );            // set size to minimum size as calculated by the sizer
 	//topsizer->SetSizeHints( this );   // set size hints to honour mininum size
 }
 


### PR DESCRIPTION
see forum topic ["Preferences window for Latency/Misc display is garbled"](http://essej.net/slforum/viewtopic.php?f=15&t=5058)