### PR TITLE
calculate window decoration in a cross-platform way

### DIFF
--- a/src/gui/app_frame.cpp
+++ b/src/gui/app_frame.cpp
@@ -283,6 +283,7 @@ AppFrame::on_preferred_size(int w, int h)
 		topheight += _toolbar->GetSize().GetHeight();
 	}
 
+	SetSizeHints (w, h + topheight);
 	SetSize (w, h + topheight);
 }
 


### PR DESCRIPTION
fixes improper window resize when add/remove loops if OS has extra window border (https://github.com/essej/sooperlooper/issues/18)

on my KDE arch machine, the resize after adding/removing a loop will now look like the following with a title bar window decoration:

![with-calculating-window-decoration-one-loop](https://user-images.githubusercontent.com/6502474/136529106-1dea3df4-f067-4111-97ff-abc1640fcdb4.png)

![with-calculating-window-decoration-two-loops](https://user-images.githubusercontent.com/6502474/136529355-a4cc1185-ca8e-43b2-a568-e2786959e16b.png)

and when I disable the titlebar window decoration:

![with-calculating-window-decoration-without-borders-one-loop](https://user-images.githubusercontent.com/6502474/136529452-d7948415-acba-4488-b455-56fc2b7323dd.png)

![with-calculating-window-decoration-without-borders-two-loops](https://user-images.githubusercontent.com/6502474/136529455-da41fb77-f112-4265-8fa1-3fdd9b1add85.png)

 I haven't tested on Mac cause I don't have one, but I believe and hope this will work on mac without having to manually add 32 to account for the title bar.  And I don't know how to enable embedded mode to test this (I guess that is if it is a plugin?).  Though if I did mess something up on Mac, then I could put my code inside the #ifndef __WXMAC__ block.