### PR TITLE
Sooperlooper crashes when starting another audio program under Pipewire on Fedora 34.

### DIFF
--- a/src/looper.cpp
+++ b/src/looper.cpp
@@ -176,8 +176,6 @@ Looper::initialize (unsigned int index, unsigned int chan_count, float loopsecs,
 					     RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionTransientsCrisp);
 
 	
-	set_buffer_size(_driver->get_buffersize());
-	
 	memset (_instances, 0, sizeof(LADSPA_Handle) * _chan_count);
 	memset (_input_ports, 0, sizeof(port_id_t) * _chan_count);
 	memset (_output_ports, 0, sizeof(port_id_t) * _chan_count);
@@ -189,6 +187,8 @@ Looper::initialize (unsigned int index, unsigned int chan_count, float loopsecs,
 	  _down_stamps[i] = 1 << 31;
 	}
         */
+
+	set_buffer_size(_driver->get_buffersize());
 
 	_longpress_frames = (nframes_t) lrint (srate * 1.0); // more than 1 secs is SUS
 	_doubletap_frames = (nframes_t) lrint (srate * 0.5); // less than 0.5 sec is double tap

--- a/src/looper.cpp
+++ b/src/looper.cpp
@@ -555,6 +555,8 @@ Looper::set_buffer_size (nframes_t bufsize)
 {
 	if (_buffersize != bufsize) {
 		//cerr << "setting buffer size to " << bufsize << endl;
+		_buffersize = bufsize;
+
 		if (_use_sync_buf == _our_syncin_buf) {
 			_use_sync_buf = 0;
 		}
@@ -576,8 +578,6 @@ Looper::set_buffer_size (nframes_t bufsize)
 
 			_tmp_io_bufs[i] = new float[_buffersize];
 		}
-		
-		_buffersize = bufsize;
 		
 		_our_syncin_buf = new float[_buffersize];
 		_our_syncout_buf = new float[_buffersize];

--- a/src/midi_bridge.cpp
+++ b/src/midi_bridge.cpp
@@ -723,6 +723,7 @@ void * MidiBridge::clock_thread_entry()
 
 	//cerr << "entering clock thread" << endl;
 	
+	FD_ZERO(&pfd);
 	while (!_clockdone) {
 		nfds = 0;
 


### PR DESCRIPTION
I've been running into a crash while running sooperlooper.  This PR fixes it, but let me know if you'd like me to file a separate issue (or go through any other hoops, it's my first time contributing so please be nice :)

Behaviour: sooperlooper crashes when playing audio from another stream running to the same sink (eg Firefox or Spotify).  This is running under Pipewire using pipewire-jack-audio-connection-kit on Fedora 34

Steps to reproduce:
1. Start sooperlooper engine and GUI, load a session
2. Click "pause" to resume playback.
3. Hit the play button in Spotify.  Or open Youtube on Firefox (appears to be any action that attaches to the output sink)

I traced down the issue by running sooperlooper under Valgrind, and fixing memory errors until the crash went away.  I believe the final commit about `_tmp_io_bufs` fixes the root cause.  The buffers were being allocated with the old buffer size, instead of the new buffer size, which was overwriting other buffers causing (in my case) invalid free() errors.  I believe the other two commits are valuable as well.

Let me know if you've any questions or comments.