### PR TITLE
refactor fit scroll area

### DIFF
--- a/src/gui/app_frame.cpp
+++ b/src/gui/app_frame.cpp
@@ -161,10 +161,7 @@ AppFrame::init()
 	
 	wxFont sliderFont = *wxSMALL_FONT;
 
-	
 	_mainpanel = new MainPanel(this, -1, wxDefaultPosition, wxDefaultSize);
-
-	_mainpanel->PreferredSizeChange.connect (mem_fun (*this,  &AppFrame::on_preferred_size));
 
 	_mainpanel->set_force_local(_embedded);
 	
@@ -248,12 +245,8 @@ AppFrame::init()
 
 
     _topsizer->Add (_mainpanel, 1, wxEXPAND);
-
-	
-	this->SetAutoLayout( true );     // tell dialog to use sizer
-	this->SetSizer( _topsizer );      // actually set the sizer
-	_topsizer->Fit( this );            // set size to minimum size as calculated by the sizer
-	_topsizer->SetSizeHints( this );   // set size hints to honour mininum size
+    
+    SetSizerAndFit(_topsizer);
 }
 
 
@@ -270,29 +263,6 @@ AppFrame::OnActivate(wxActivateEvent &ev)
 	ev.Skip();
 	
 }
-
-void
-AppFrame::on_preferred_size(int w, int h)
-{
-	int topheight = 0;
-#ifndef __WXMAC__
-	if (GetMenuBar()) {
-		topheight += GetMenuBar()->GetSize().GetHeight();
-	}
-#else
-	topheight += 32;
-
-    if (_embedded && _toolbar) {
-        topheight += _toolbar->GetSize().GetHeight();
-    }
-
-#endif
-
-	//if (!_embedded) {
-        SetSize (w, h + topheight);
-    //}
-}
-
 
 void
 AppFrame::OnClose(wxCloseEvent &event)

--- a/src/gui/app_frame.hpp
+++ b/src/gui/app_frame.hpp
@@ -67,8 +67,6 @@ public:
 protected:
 
 	void init();
-
-	void on_preferred_size(int w, int h);
 	
 	void on_add_loop (wxCommandEvent &ev);
 	void on_add_custom_loop (wxCommandEvent &ev);

--- a/src/gui/gui_app.cpp
+++ b/src/gui/gui_app.cpp
@@ -341,17 +341,13 @@ bool GuiApp::OnInit()
 	// connect
 	//loopctrl.connect();
 
-	// Show it and tell the application that it's our main window
-	_frame->SetSizeHints(850, 210);
-	_frame->SetSize(_screen_pos.x, _screen_pos.y, 860, 215);
-
+	// Show it with minimum size and tell the application that it's our main window
+	_frame->SetSize(_screen_pos.x, _screen_pos.y, _frame->GetMinWidth(), _frame->GetMinHeight());
 	SetTopWindow(_frame);
-
 	_frame->Show(FALSE);
 	_frame->Raise();
 	_frame->Show(TRUE);
 
-		
 	// success: wxApp::OnRun() will be called which will enter the main message
 	// loop and the application will run. If we returned FALSE here, the
 	// application would exit immediately.

--- a/src/gui/main_panel.cpp
+++ b/src/gui/main_panel.cpp
@@ -201,7 +201,7 @@ MainPanel::~MainPanel()
 void
 MainPanel::init()
 {
-	_main_sizer = new wxBoxSizer(wxVERTICAL);
+	_scroller_sizer = new wxBoxSizer(wxVERTICAL);
 	_topsizer = new wxBoxSizer(wxVERTICAL);
 
 	//wxBoxSizer * rowsizer = new wxBoxSizer(wxHORIZONTAL);
@@ -375,13 +375,11 @@ MainPanel::init()
 
 	
 	_top_panel->SetSizer( topcolsizer );      // actually set the sizer
-	topcolsizer->Fit( _top_panel );            // set size to minimum size as calculated by the sizer
-	topcolsizer->SetSizeHints( _top_panel );   // set size hints to honour mininum size
 
 	_topsizer->Add (_top_panel, 0, wxEXPAND);
 
 	
-	_scroller = new wxScrolledWindow(this, -1, wxDefaultPosition, wxDefaultSize, wxVSCROLL);
+	_scroller = new wxScrolledWindow(this, -1, wxDefaultPosition, wxSize(846, 118), wxVSCROLL); // initial size should fit one loop
 	_scroller->SetBackgroundColour(*wxBLACK);
 	
 
@@ -394,20 +392,12 @@ MainPanel::init()
 
 	_topsizer->Add (_scroller, 1, wxEXPAND);
 	
-	_scroller->SetSizer( _main_sizer );      // actually set the sizer
-	_scroller->SetAutoLayout( true );     // tell dialog to use sizer
+	_scroller->SetSizer( _scroller_sizer );      // actually set the sizer
 
 	_scroller->SetScrollRate (0, 30);
 	_scroller->EnableScrolling (true, true);
-
-	//_main_sizer->Fit( _scroller );            // set size to minimum size as calculated by the sizer
-	_main_sizer->SetSizeHints( _scroller );   // set size hints to honour mininum size
-
 	
-	this->SetAutoLayout( true );     // tell dialog to use sizer
 	this->SetSizer( _topsizer );      // actually set the sizer
-	_topsizer->Fit( this );            // set size to minimum size as calculated by the sizer
-	_topsizer->SetSizeHints( this );   // set size hints to honour mininum size
 
 	_scroller->SetFocus();
 }
@@ -448,7 +438,7 @@ MainPanel::init_loopers (int count)
 		while (count > (int) _looper_panels.size()) {
 			looperpan = new LooperPanel(this, _loop_control, _scroller, -1);
 			looperpan->set_index(_looper_panels.size());
-			_main_sizer->Add (looperpan, 0, wxEXPAND|wxALL, 0);
+			_scroller_sizer->Add (looperpan, 0, wxEXPAND|wxALL, 0);
 			_looper_panels.push_back (looperpan);
 		}
 	}
@@ -456,40 +446,21 @@ MainPanel::init_loopers (int count)
 		while (count < (int)_looper_panels.size()) {
 			looperpan = _looper_panels.back();
 			_looper_panels.pop_back();
-			_main_sizer->Remove((wxBoxSizer*)looperpan);
+			_scroller_sizer->Remove((wxBoxSizer*)looperpan);
 			looperpan->Destroy();
 		}
 	}
 
-	_scroller->SetClientSize(_scroller->GetClientSize());
 	_scroller->Layout();
-	_scroller->SetScrollRate(0,30);
+	_scroller->FitInside();
 
- 	if (!_looper_panels.empty()) {
- 		wxSize bestsz = _looper_panels[0]->GetBestSize();
-		//cerr << "best w: " << bestsz.GetWidth() << endl;
- 		_scroller->SetMinClientSize (bestsz);
-		_topsizer->Layout();
-// 		_topsizer->Fit(this);
-// 		_topsizer->SetSizeHints(this);
-
-		
-		// maybe resize
-		if (_looper_panels.size() <= 4) {
-			int topheight = _top_panel->GetSize().GetHeight();
-
-			//SetSize(GetSize().GetWidth(), bestsz.GetHeight() * _looper_panels.size()  + topheight); 
-			PreferredSizeChange(GetSize().GetWidth(), bestsz.GetHeight() * _looper_panels.size()  + topheight); // emit
-		}
-		
-		
+	// maybe resize topwindow, keeping width the same, but resize height to be just big enough to hold the updated number of looper panels
+	if (_looper_panels.size() > 0 && _looper_panels.size() <= 4) {
+		wxTopLevelWindow *topwindow = wxStaticCast(wxGetTopLevelParent(this), wxTopLevelWindow);
+		if (topwindow && topwindow->IsIconized() == false) // don't trigger refit if minimized
+			topwindow->SetClientSize(GetSize().GetWidth(), _top_panel->GetSize().GetHeight() + _scroller_sizer->GetMinSize().GetHeight());
  	}
-	
 
-	//_main_sizer->Layout();
-	//_main_sizer->Fit(_scroller);
-	//_main_sizer->SetSizeHints( _scroller );   // set size hints to honour mininum size
-	
 	// request all values for initial state
 	_loop_control->register_all_in_new_thread(_looper_panels.size());
 

--- a/src/gui/main_panel.hpp
+++ b/src/gui/main_panel.hpp
@@ -104,8 +104,6 @@ public:
 	void save_default_midibindings ();
 
 	wxString do_file_selector(const wxString & message, const wxString & ext, const wxString & wc, int style);
-	
-	sigc::signal2<void,int, int> PreferredSizeChange;
 
     void set_sliders_allow_mousewheel (bool flag);
     bool get_sliders_allow_mousewheel () const { return _sliders_allow_mousewheel; }
@@ -178,7 +176,7 @@ protected:
 	wxTimer * _taptempo_button_timer;
 
 	wxScrolledWindow * _scroller;
-	wxBoxSizer * _main_sizer;
+	wxBoxSizer * _scroller_sizer;
 	wxBoxSizer * _topsizer;
 	wxPanel    * _top_panel;
 


### PR DESCRIPTION
To fix #18.  Rather than how the original code tries to manually calculate the new height of the window when adding/removing loops, this PR uses SetMinClientArea to set a minimum size constraint on the scroll area, and then lets the AppFrame's Fit() built-in function automatically resize everything based on that constraint.

(WIP cause I need to figure why won't properly redraw if the window was minimized while loops are added/removed.  And I need to test on other OSes and don't have a mac)