### PR TITLE
Add global cycle pos cmds and show it in gui

### DIFF
--- a/src/command_map.cpp
+++ b/src/command_map.cpp
@@ -173,6 +173,8 @@ CommandMap::CommandMap()
 	add_global_control("use_midi_start", Event::UseMidiStart, UnitBoolean, 0.0f, 1.0f, 1.0f);
 	add_global_control("use_midi_stop", Event::UseMidiStop, UnitBoolean, 0.0f, 1.0f, 1.0f);
 	add_global_control("send_midi_start_on_trigger", Event::SendMidiStartOnTrigger, UnitBoolean, 0.0f, 1.0f, 1.0f);
+	add_global_control("global_cycle_len", Event::GlobalCycleLen, UnitSeconds, 0.0f, 1e6);
+	add_global_control("global_cycle_pos", Event::GlobalCyclePos, UnitSeconds, 0.0f, 1e6);
 	_str_ctrl_map.insert (_global_controls.begin(), _global_controls.end());
 
 	// reverse it

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1542,6 +1542,12 @@ Engine::get_control_value (Event::control_t ctrl, int8_t instance)
 		else if (ctrl == Event::JackTimebaseMaster) {
 			return _jack_timebase_master ? 1.0f: 0.0f;
 		}
+		else if (ctrl == Event::GlobalCycleLen) {
+			return _tempo_frames / _driver->get_samplerate();
+		}
+		else if (ctrl == Event::GlobalCyclePos) {
+			return _tempo_counter / _driver->get_samplerate();
+		}
 
 	}
 

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -220,7 +220,9 @@ namespace SooperLooper {
 		    // Put all new controls at the end to avoid screwing up the order of existing AU sessions (who store these numbers)
 		    ReplaceQuantized,
 		    SendMidiStartOnTrigger,
-            DiscretePreFader
+		    DiscretePreFader,
+		    GlobalCycleLen,
+		    GlobalCyclePos
 	    } Control;
 	    
 	    int8_t  Instance;

--- a/src/gui/choice_box.cpp
+++ b/src/gui/choice_box.cpp
@@ -58,6 +58,7 @@ ChoiceBox::ChoiceBox(wxWindow * parent, wxWindowID id, bool bindable, const wxPo
 	_popup_menu = 0;
 	_data_value = 0;
 	_bindable = bindable;
+	_bar_value = 0.0f;
 	
 	_bgcolor.Set(0,0,0);
 	_bgbrush.SetColour (_bgcolor);
@@ -69,7 +70,7 @@ ChoiceBox::ChoiceBox(wxWindow * parent, wxWindowID id, bool bindable, const wxPo
 	_textcolor = *wxWHITE;
 	_barcolor.Set(14, 50, 89);
 	_overbarcolor.Set(20, 40, 50);
-	_barbrush.SetColour(_bgcolor);
+	_barbrush.SetColour(_barcolor);
 	
 	_bgbordercolor.Set(30,30,30);
 	_bordercolor.Set(67, 83, 103);
@@ -429,6 +430,11 @@ void ChoiceBox::draw_area(wxDC & dc)
 	shape[5].x = _width -1;  shape[5].y = _height -1;
 
 	dc.DrawPolygon (6, shape);
+
+	if (_bar_value > 0.0f) {
+		dc.SetBrush(_barbrush);
+		dc.DrawRectangle (1, 1, (wxCoord)(_width*_bar_value-1), _height-2);
+	}
 	
 	dc.SetPen(*wxTRANSPARENT_PEN);
 
@@ -442,4 +448,15 @@ void ChoiceBox::draw_area(wxDC & dc)
 	dc.DrawText (_value_str, _width - w - 3, _height - h - 3);
 	
 
+}
+
+void ChoiceBox::set_bar_value(float val) {
+	if(val >= 0.0f && val <= 1.0f && _bar_value != val) {
+		_bar_value = val;
+		Refresh(false);
+	}
+}
+
+float ChoiceBox::get_bar_value() {
+	return _bar_value;
 }

--- a/src/gui/choice_box.hpp
+++ b/src/gui/choice_box.hpp
@@ -81,6 +81,8 @@ class ChoiceBox
     static void set_use_mousewheel_default (bool flag) { s_use_wheel_def = flag; }
     static bool get_use_mousewheel_default () { return s_use_wheel_def; }
 
+    void set_bar_value (float val);
+    float get_bar_value ();
     
 	sigc::signal2<void, int, wxString> value_changed;
 	sigc::signal0<void> bind_request;
@@ -138,6 +140,7 @@ class ChoiceBox
 
 	bool _dragging;
 	int _last_x;
+	float _bar_value;
 	
   private:
     // any class wishing to process wxWindows events must use this macro

--- a/src/gui/loop_control.cpp
+++ b/src/gui/loop_control.cpp
@@ -385,10 +385,14 @@ LoopControl::register_global_updates(bool unreg)
 	if (unreg) {
 		lo_send(_osc_addr, "/unregister_auto_update", "siss", "in_peak_meter", 100, _our_url.c_str(), "/ctrl");
 		lo_send(_osc_addr, "/unregister_auto_update", "siss", "out_peak_meter", 100, _our_url.c_str(), "/ctrl");
+		lo_send(_osc_addr, "/unregister_auto_update", "siss", "global_cycle_len", 100, _our_url.c_str(), "/ctrl");
+		lo_send(_osc_addr, "/unregister_auto_update", "siss", "global_cycle_pos", 100, _our_url.c_str(), "/ctrl");
 	}
 	else {
 		lo_send(_osc_addr, "/register_auto_update", "siss", "in_peak_meter", 100, _our_url.c_str(), "/ctrl");
 		lo_send(_osc_addr, "/register_auto_update", "siss", "out_peak_meter", 100, _our_url.c_str(), "/ctrl");
+		lo_send(_osc_addr, "/register_auto_update", "siss", "global_cycle_len", 100, _our_url.c_str(), "/ctrl");
+		lo_send(_osc_addr, "/register_auto_update", "siss", "global_cycle_pos", 100, _our_url.c_str(), "/ctrl");
 	}
 }
 

--- a/src/gui/main_panel.cpp
+++ b/src/gui/main_panel.cpp
@@ -92,7 +92,8 @@ enum {
 	ID_MuteQuantCheck,
 	ID_OdubQuantCheck,
 	ID_SmartEighthCheck,
-	ID_ReplQuantCheck
+	ID_ReplQuantCheck,
+	ID_GlobalCyclePos
 };
 
 
@@ -293,7 +294,6 @@ MainPanel::init()
 	_repl_quant_check->value_changed.connect (mem_fun (*this, &MainPanel::on_repl_quant_check));
 	_repl_quant_check->bind_request.connect (sigc::bind(mem_fun (*this, &MainPanel::on_bind_request), wxT("replace_quantized")));
 	rowsizer->Add (_repl_quant_check, 0, wxALL|wxEXPAND, 2);
-
 
 	rowsizer->Add (1, 1, 1);
 
@@ -740,6 +740,18 @@ MainPanel::update_controls()
 		_loop_control->get_global_value(wxT("selected_loop_num"), val);
 		set_curr_loop ((int) val);
 	}
+
+	if (_loop_control->is_global_updated(wxT("global_cycle_pos"))) {
+		float gclen, gcpos;
+		_loop_control->get_global_value(wxT("global_cycle_len"), gclen);
+		_loop_control->get_global_value(wxT("global_cycle_pos"), gcpos);
+		val = 0.0f;
+		// only display global cycle len if it is >= 1s to reduce visual noise
+		if(gclen >= 1.0f)
+			val = gcpos / gclen;
+		_quantize_choice->set_bar_value(val);
+	}
+
 }
 
 void


### PR DESCRIPTION
This commit adds the commands "global_cycle_len" and "global_cycle_pos"
to sooperlooper and a gui element showing the position in the current
sooperlooper cycle. This feature only works in Internal or Jack sync
mode with quantize set to cycle or 8th (i.e. whenever sooperlooper
actually has an internal cycle).

When recording the first loop in sync internal + quantize cycle + first
loop on sync it is hard to hit the first note at the beginning of the
cycle. A visual indicator of where we are in the cycle helps to be on
time in situation where no other cue is available.

The gui element has currently no text and only displays the current
cycle if its length is >= 1s. Both of these measures have been taken to
reduce visual noise in the gui.

---

Soo, I've been having this problem with not knowing where in the sooperlooper cycle I was when I wanted to record my first loop, so I decided to make it visible. Display is done with a SliderBar, which I think is quite neat for displaying this (..or it's the best widget I've found on short notice to do the job). I hope this is useful to someone else as well.

This is my first deep dive into the sooperlooper source and I tried to orient myself a bit on the code surrounding my changes. Also, if you think the new widget in the top bar creates too much visual noise here's a couple things we could still implement:
 * hide the widget when we're not in sync mode jack/internal and when the global cycle is shorter than 1s
 * make display of this widget configurable via preferences

Though I had some trouble with hiding/displaying that widget. Reviews / comments welcome! ;)