### PR TITLE
Add setting to copy loop flags on loop create

### DIFF
--- a/src/gui/latency_panel.cpp
+++ b/src/gui/latency_panel.cpp
@@ -44,7 +44,8 @@ enum {
 	ID_UseMidiStop,
 	ID_SendMidiStartOnTrigger,
 	ID_OutputClockCheck,
-    ID_SliderMousewheelCheck
+    ID_SliderMousewheelCheck,
+    ID_CopyLoopValuesOnCreateCheck
 };
 
 BEGIN_EVENT_TABLE(SooperLooperGui::LatencyPanel, wxPanel)
@@ -57,6 +58,7 @@ BEGIN_EVENT_TABLE(SooperLooperGui::LatencyPanel, wxPanel)
 	EVT_CHECKBOX (ID_SendMidiStartOnTrigger, SooperLooperGui::LatencyPanel::on_check)
     EVT_CHECKBOX(ID_OutputClockCheck, SooperLooperGui::LatencyPanel::on_check)
     EVT_CHECKBOX(ID_SliderMousewheelCheck, SooperLooperGui::LatencyPanel::on_check)
+    EVT_CHECKBOX(ID_CopyLoopValuesOnCreateCheck, SooperLooperGui::LatencyPanel::on_check)
 	EVT_TIMER(ID_UpdateTimer, SooperLooperGui::LatencyPanel::OnUpdateTimer)
 
 	EVT_SIZE (SooperLooperGui::LatencyPanel::onSize)
@@ -195,6 +197,8 @@ void LatencyPanel::init()
 	_slider_mousewheel_check = new wxCheckBox(this, ID_SliderMousewheelCheck, wxT("Allow mouse scroll wheel to change sliders"));
 	topsizer->Add(_slider_mousewheel_check, 0, wxALL, 3);
 
+	_copy_loop_values_on_create_check = new wxCheckBox(this, ID_CopyLoopValuesOnCreateCheck, wxT("Copy loop flags from last loop when creating a new one"));
+	topsizer->Add(_copy_loop_values_on_create_check, 0, wxALL, 3);
 
 	_update_timer = new wxTimer(this, ID_UpdateTimer);
 	_update_timer->Start(5000, true);
@@ -258,6 +262,7 @@ void LatencyPanel::refresh_state()
 	}
 
     _slider_mousewheel_check->SetValue(_parent->get_sliders_allow_mousewheel() );
+    _copy_loop_values_on_create_check->SetValue(_parent->get_copy_loop_values() );
 
         
 	if (_auto_check->GetValue()) {
@@ -302,6 +307,9 @@ void LatencyPanel::on_check (wxCommandEvent &ev)
         }
 	else if (ev.GetId() == ID_AutoDisableCheck) {
 		lcontrol.post_ctrl_change (-2, wxT("auto_disable_latency"), _auto_disable_check->GetValue() ? 1.0f : 0.0f);
+	}
+	else if (ev.GetId() == ID_CopyLoopValuesOnCreateCheck) {
+		_parent->set_copy_loop_values (_copy_loop_values_on_create_check->GetValue());
 	}
     
 

--- a/src/gui/latency_panel.hpp
+++ b/src/gui/latency_panel.hpp
@@ -81,6 +81,7 @@ class LatencyPanel
 	wxCheckBox * _output_clock_check;
 
 	wxCheckBox * _slider_mousewheel_check;
+	wxCheckBox * _copy_loop_values_on_create_check;
 
 
     MainPanel * _parent;

--- a/src/gui/main_panel.hpp
+++ b/src/gui/main_panel.hpp
@@ -89,6 +89,8 @@ public:
 	
 	void set_force_local(bool flag) { _force_local = flag; }
     bool get_force_local() const { return _force_local; }
+    void set_copy_loop_values(bool flag) { _copy_loop_values = flag; }
+    bool get_copy_loop_values() { return _copy_loop_values; }
     
 	void init_loopers (int count);
 
@@ -226,6 +228,8 @@ protected:
 	wxString      _last_used_path;
 
     bool _sliders_allow_mousewheel;
+    bool _copy_loop_values;
+    int _copy_loop_values_counter;
 
 private:
     // any class wishing to process wxWindows events must use this macro


### PR DESCRIPTION
A new setting now controls if a newly created loop inherits all flags
from the previous loop (sync, play sync, feedback play, tempo stretch,
discrete prefader). This is a gui-only implementation. The MainPanel
class has an extra counter to track when this instance of slgui has
created a panel, to then copy the values over. This was done to not
interfere with other sooperlooper clients that might not wish the values
to be copied.

---

I didn't want to re-click all the sync-flags for each loop whenever I added a new loop (also I forgot to do that many times and wondered why my new loops suddenly behaved differently, a complete mystery™), so here's a flag to just do that! In my first draft I tried to implement that in `MainPanel::do_add_loop()`, but it didn't work. I presume the loops were not ready yet in the server and thus my set-commands were discarded, though I didn't investigate this any further. I then went ahead with implementing it in `MainPanel::init_loopers()`. I hope the update-commands are not blocking the GUI loop or anything, but in my tests it felt smooth enough.

I saw this feature was discussed [in the sooperlooper forum](http://essej.net/slforum/viewtopic.php?f=2&t=5057), so @ericfont maybe this might be interesting to you as well. It's not a "remember default settings" implementation, only a "copy from last loop", but still might do the trick.