### PR TITLE
fix permissive build issues with liblo callbacks

### DIFF
--- a/src/control_osc.cpp
+++ b/src/control_osc.cpp
@@ -512,7 +512,7 @@ ControlOSC::osc_receiver()
 
 
 int ControlOSC::_dummy_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 #ifdef DEBUG
 	cerr << "got path: " << path << endl;
@@ -522,7 +522,7 @@ int ControlOSC::_dummy_handler(const char *path, const char *types, lo_arg **arg
 
 
 int ControlOSC::_quit_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->quit_handler (path, types, argv, argc, data);
@@ -530,7 +530,7 @@ int ControlOSC::_quit_handler(const char *path, const char *types, lo_arg **argv
 }
 
 int ControlOSC::_ping_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->ping_handler (path, types, argv, argc, data);
@@ -538,14 +538,14 @@ int ControlOSC::_ping_handler(const char *path, const char *types, lo_arg **argv
 }
 
 int ControlOSC::_global_set_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_set_handler (path, types, argv, argc, data);
 
 }
 int ControlOSC::_global_get_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_get_handler (path, types, argv, argc, data);
@@ -554,21 +554,21 @@ int ControlOSC::_global_get_handler(const char *path, const char *types, lo_arg 
 
 
 int ControlOSC::_updown_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->updown_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_set_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->set_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_get_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->get_handler (path, types, argv, argc, data, cp);
@@ -589,105 +589,105 @@ int ControlOSC::_get_prop_handler(const char *path, const char *types, lo_arg **
 }
 
 int ControlOSC::_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->register_update_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->unregister_update_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->register_auto_update_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->unregister_auto_update_handler (path, types, argv, argc, data, cp);
 }
 
-int ControlOSC::_loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->loop_add_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->loop_del_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->load_session_handler (path, types, argv, argc, data);
 }
-int ControlOSC::_save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->save_session_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_register_config_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->register_config_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->unregister_config_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->loadloop_handler (path, types, argv, argc, data, cp);
 }
 
-int ControlOSC::_saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->saveloop_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_register_update_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_unregister_update_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_register_auto_update_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_unregister_auto_update_handler (path, types, argv, argc, data);
@@ -695,27 +695,27 @@ int ControlOSC::_global_unregister_auto_update_handler(const char *path, const c
 
 
 int ControlOSC::_midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->midi_start_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->midi_stop_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->midi_tick_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data)
 {
 	MidiBindCommand * cp = static_cast<MidiBindCommand*> (user_data);
 	return cp->osc->midi_binding_handler (path, types, argv, argc, data, cp);
@@ -724,14 +724,14 @@ int ControlOSC::_midi_binding_handler(const char *path, const char *types, lo_ar
 
 /* real callbacks */
 
-int ControlOSC::quit_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+int ControlOSC::quit_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	_engine->quit();
 	return 0;
 }
 
 
-int ControlOSC::ping_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+int ControlOSC::ping_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	string returl (&argv[0]->s);
 	string retpath (&argv[1]->s);
@@ -755,7 +755,7 @@ int ControlOSC::ping_handler(const char *path, const char *types, lo_arg **argv,
 }
 
 
-int ControlOSC::global_get_handler(const char *path, const char *types, lo_arg **argv, int argc,void *data)
+int ControlOSC::global_get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// s: param  s: returl  s: retpath
 	string param (&argv[0]->s);
@@ -768,7 +768,7 @@ int ControlOSC::global_get_handler(const char *path, const char *types, lo_arg *
 	return 0;
 }
 
-int ControlOSC::global_set_handler(const char *path, const char *types, lo_arg **argv, int argc,void *data)
+int ControlOSC::global_set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// s: param  f: val
 	string param(&argv[0]->s);
@@ -787,7 +787,7 @@ int ControlOSC::global_set_handler(const char *path, const char *types, lo_arg *
 }
 
 int
-ControlOSC::global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// un/register_update args= s:ctrl s:returl s:retpath
 	string ctrl (&argv[0]->s);
@@ -804,7 +804,7 @@ ControlOSC::global_register_update_handler(const char *path, const char *types, 
 }
 
 int
-ControlOSC::global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// 1st is return URL string 2nd is retpath
 	string ctrl (&argv[0]->s);
@@ -821,7 +821,7 @@ ControlOSC::global_unregister_update_handler(const char *path, const char *types
 }
 
 int
-ControlOSC::global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// first arg is control string, 2nd is every int millisecs, 3rd is return URL string 4th is retpath
 	string ctrl (&argv[0]->s);
@@ -848,7 +848,7 @@ ControlOSC::global_register_auto_update_handler(const char *path, const char *ty
 }
 
 int
-ControlOSC::global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// 1st is return URL string 2nd is retpath
 	string ctrl (&argv[0]->s);
@@ -869,7 +869,7 @@ ControlOSC::global_unregister_auto_update_handler(const char *path, const char *
 
 
 int
-ControlOSC::midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, MidiBindCommand * info)
+ControlOSC::midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, MidiBindCommand * info)
 {
 	if (info->command == MidiBindCommand::GetAllBinding)
 	{
@@ -967,7 +967,7 @@ ControlOSC::midi_binding_handler(const char *path, const char *types, lo_arg **a
 
 
 int
-ControlOSC::midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	_engine->push_sync_event (Event::MidiStart);
 	return 0;
@@ -975,7 +975,7 @@ ControlOSC::midi_start_handler(const char *path, const char *types, lo_arg **arg
 
 
 int
-ControlOSC::midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	_engine->push_sync_event (Event::MidiStop);
 	return 0;
@@ -983,14 +983,14 @@ ControlOSC::midi_stop_handler(const char *path, const char *types, lo_arg **argv
 
 
 int
-ControlOSC::midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	_engine->push_sync_event (Event::MidiTick);
 	return 0;
 }
 
 
-int ControlOSC::updown_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::updown_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 	// first arg is a string
 	
@@ -1002,7 +1002,7 @@ int ControlOSC::updown_handler(const char *path, const char *types, lo_arg **arg
 }
 
 
-int ControlOSC::set_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 
 	// first arg is a control string, 2nd is float val
@@ -1021,7 +1021,7 @@ int ControlOSC::set_handler(const char *path, const char *types, lo_arg **argv, 
 
 }
 
-int ControlOSC::get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 
 	// first arg is control string, 2nd is return URL string 3rd is retpath
@@ -1039,7 +1039,7 @@ int ControlOSC::get_prop_handler(const char *path, const char *types, lo_arg **a
 	return 0;
 }
 
-int ControlOSC::set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 	// first arg is a control string, 2nd is string val
 
@@ -1056,7 +1056,7 @@ int ControlOSC::set_prop_handler(const char *path, const char *types, lo_arg **a
 	return 0;
 }
 
-int ControlOSC::loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+int ControlOSC::loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// 1st is an int #channels
 	// 2nd is a float #bytes per channel (if 0, use engine default) 
@@ -1074,7 +1074,7 @@ int ControlOSC::loop_add_handler(const char *path, const char *types, lo_arg **a
 	return 0;
 }
 
-int ControlOSC::loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+int ControlOSC::loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// 1st is index of loop to delete
 	
@@ -1086,7 +1086,7 @@ int ControlOSC::loop_del_handler(const char *path, const char *types, lo_arg **a
 }
 
 
-int ControlOSC::load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+int ControlOSC::load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 
 	// first arg is fname, 2nd is return URL string 3rd is retpath
@@ -1102,7 +1102,7 @@ int ControlOSC::load_session_handler(const char *path, const char *types, lo_arg
 	return 0;
 }
 
-int ControlOSC::save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+int ControlOSC::save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 
 	// first arg is fname, 2nd is return URL string 3rd is retpath
@@ -1124,7 +1124,7 @@ int ControlOSC::save_session_handler(const char *path, const char *types, lo_arg
 }
 
 
-int ControlOSC::loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 
 	// first arg is fname, 2nd is return URL string 3rd is retpath
@@ -1140,7 +1140,7 @@ int ControlOSC::loadloop_handler(const char *path, const char *types, lo_arg **a
 	return 0;
 }
 
-int ControlOSC::saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 	// save loop:  s:filename  s:format s:endian s:returl  s:retpath
 	string fname (&argv[0]->s);
@@ -1199,7 +1199,7 @@ ControlOSC::find_or_cache_addr(string returl)
 	return addr;
 }
 
-int ControlOSC::get_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 	// cerr << "get " << path << endl;
 
@@ -1216,7 +1216,7 @@ int ControlOSC::get_handler(const char *path, const char *types, lo_arg **argv, 
 	return 0;
 }
 
-int ControlOSC::register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 	// first arg is control string, 2nd is return URL string 3rd is retpath
 	string ctrl (&argv[0]->s);
@@ -1232,7 +1232,7 @@ int ControlOSC::register_update_handler(const char *path, const char *types, lo_
 	return 0;
 }
 
-int ControlOSC::unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 
 	// first arg is control string, 2nd is return URL string 3rd is retpath
@@ -1248,7 +1248,7 @@ int ControlOSC::unregister_update_handler(const char *path, const char *types, l
 	return 0;
 }
 
-int ControlOSC::register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 	// first arg is control string, 2nd is every int millisecs, 3rd is return URL string 4th is retpath
 	string ctrl (&argv[0]->s);
@@ -1272,7 +1272,7 @@ int ControlOSC::register_auto_update_handler(const char *path, const char *types
 	return 0;
 }
 
-int ControlOSC::unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo *info)
+int ControlOSC::unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo *info)
 {
 
 	// first arg is control string, 2nd is return URL string 3rd is retpath
@@ -1290,7 +1290,7 @@ int ControlOSC::unregister_auto_update_handler(const char *path, const char *typ
 
 
 int
-ControlOSC::register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// 1st is return URL string 2nd is retpath
 	string returl (&argv[0]->s);
@@ -1304,7 +1304,7 @@ ControlOSC::register_config_handler(const char *path, const char *types, lo_arg 
 }
 
 int
-ControlOSC::unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+ControlOSC::unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// 1st is return URL string 2nd is retpath
 	string returl (&argv[0]->s);

--- a/src/control_osc.hpp
+++ b/src/control_osc.hpp
@@ -118,39 +118,39 @@ class ControlOSC
 	lo_address find_or_cache_addr(std::string returl);
 
 	
-	static int _quit_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_set_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_get_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _updown_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _set_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _get_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _dummy_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _ping_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
+	static int _quit_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _global_set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _global_get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _updown_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _dummy_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _ping_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
 
 	
-	static int _midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
+	static int _midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
+	static int _midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
 
-	static int _midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
+	static int _midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, void *user_data);
 
 
 	bool init_osc_thread();
@@ -160,40 +160,40 @@ class ControlOSC
 	static void * _osc_receiver(void * arg);
 	void osc_receiver();
 	
-	int quit_handler(const char *path, const char *types, lo_arg **argv, int argc,void *data);
-	int ping_handler(const char *path, const char *types, lo_arg **argv, int argc,void *data);
-	int global_get_handler(const char *path, const char *types, lo_arg **argv, int argc,void *data);
-	int global_set_handler(const char *path, const char *types, lo_arg **argv, int argc,void *data);
-	int loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
+	int quit_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int ping_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int global_get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int global_set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
 
-	int global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-
-	
-	int midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
-	int midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, MidiBindCommand * info);
+	int global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
 
 	
-	int updown_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, CommandInfo * info);
-	int set_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int get_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
-	int saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data,  CommandInfo * info);
+	int midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
+	int midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, MidiBindCommand * info);
+
+	
+	int updown_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data, CommandInfo * info);
+	int set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
+	int saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data,  CommandInfo * info);
 
 	Event::command_t  to_command_t (std::string cmd);
 	std::string       to_command_str (Event::command_t cmd);

--- a/src/gui/loop_control.cpp
+++ b/src/gui/loop_control.cpp
@@ -663,14 +663,14 @@ bool LoopControl::spawn_looper()
 
 int
 LoopControl::_pingack_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->pingack_handler (path, types, argv, argc, data);
 }
 
 int
-LoopControl::pingack_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+LoopControl::pingack_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// s:hosturl  s:version  i:loopcount
 
@@ -758,14 +758,14 @@ LoopControl::pingack_handler(const char *path, const char *types, lo_arg **argv,
 
 int
 LoopControl::_alive_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->alive_handler (path, types, argv, argc, data);
 }
 
 int
-LoopControl::alive_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+LoopControl::alive_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// s:hosturl  s:version  i:loopcount [i:id]
 	if (argc > 3) {
@@ -782,14 +782,14 @@ LoopControl::alive_handler(const char *path, const char *types, lo_arg **argv, i
 
 int
 LoopControl::_error_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->error_handler (path, types, argv, argc, data);
 }
 
 int
-LoopControl::error_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+LoopControl::error_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// s:errstr
 	string errsrc(&argv[0]->s);
@@ -803,7 +803,7 @@ LoopControl::error_handler(const char *path, const char *types, lo_arg **argv, i
 
 int
 LoopControl::_control_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->control_handler (path, types, argv, argc, data);
@@ -811,7 +811,7 @@ LoopControl::_control_handler(const char *path, const char *types, lo_arg **argv
 
 
 int
-LoopControl::control_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+LoopControl::control_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// loop instance is 1st arg, 2nd is ctrl string, 3rd is float value
 
@@ -894,14 +894,14 @@ LoopControl::property_handler(const char *path, const char *types, lo_arg **argv
 
 int
 LoopControl::_midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->midi_binding_handler (path, types, argv, argc, data);
 }
 
 int
-LoopControl::midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data)
+LoopControl::midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data)
 {
 	// s:status s:serialized binding
 	string status(&argv[0]->s);

--- a/src/gui/loop_control.hpp
+++ b/src/gui/loop_control.hpp
@@ -171,9 +171,9 @@ class LoopControl
   protected:
 	
 	static int _control_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message data, void *user_data);
 
-	int control_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
+	int control_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
 
 	static int _property_handler(const char *path, const char *types, lo_arg **argv, int argc,
 				    void *data, void *user_data);
@@ -181,24 +181,24 @@ class LoopControl
 	int property_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
 
 	static int _pingack_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message data, void *user_data);
 
-	int pingack_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
+	int pingack_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
 
 	static int _midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message data, void *user_data);
 
-	int midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
+	int midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
 
 	static int _alive_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message data, void *user_data);
 
-	int alive_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
+	int alive_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
 
 	static int _error_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message data, void *user_data);
 
-	int error_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
+	int error_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message data);
 	
 	static void * _osc_traffic(void * arg);
 	void osc_traffic();

--- a/src/slconsole.cpp
+++ b/src/slconsole.cpp
@@ -273,7 +273,7 @@ static int post_event(char cmd)
 }
 
 static int ctrl_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	// 1st arg is instance, 2nd ctrl string, 3nd is float value
 	//int index = argv[0]->i;
@@ -288,7 +288,7 @@ static int ctrl_handler(const char *path, const char *types, lo_arg **argv, int 
 }
 
 static int pingack_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message data, void *user_data)
 {
 	// pingack expects: s:engine_url s:version i:loopcount
 	// 1st arg is instance, 2nd ctrl string, 3nd is float value


### PR DESCRIPTION
Building sooperlooper on gentoo fails with a lot of errors related to the gcc -fno-permissive being enabled by default. See the example error below.

This change replaces the 'void *data' parameters in liblo callbacks with 'lo_message data' and so removes those errors without having to enable -fpermissive.

Related gentoo bug: https://bugs.gentoo.org/925275

`control_osc.cpp: In member function ‘void SooperLooper::ControlOSC::register_callbacks()’:                                                                              
control_osc.cpp:148:37: error: invalid conversion from ‘int (*)(const char*, const char*, lo_arg**, int, void*, void*)’ to ‘lo_method_handler’ {aka ‘int (*)(const char*
, const char*, lo_arg**, int, lo_message_*, void*)’} [-fpermissive]                                                                                                     
  148 |                 lo_server_add_method(serv, "/quit", "", ControlOSC::_quit_handler, this);                                                                       
      |                 ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                        
      |                                     |                                                                                                                           
      |                                     int (*)(const char*, const char*, lo_arg**, int, void*, void*)                                                              
In file included from /usr/include/lo/lo.h:32,                                                                                                                          
                 from control_osc.hpp:24,                                                                                                                               
                 from control_osc.cpp:30:                                                                                                                               
/usr/include/lo/lo_lowlevel.h:876:72: note:   initializing argument 4 of ‘lo_method_* lo_server_add_method(lo_server, const char*, const char*, lo_method_handler, const
 void*)’                                                                                                                                                                
  876 |                                const char *typespec, lo_method_handler h,                                                                                       
      |                                                      ~~~~~~~~~~~~~~~~~~^                                                                                        
` 