### PR TITLE
Support liblo-0.32

### DIFF
--- a/src/control_osc.cpp
+++ b/src/control_osc.cpp
@@ -512,7 +512,7 @@ ControlOSC::osc_receiver()
 
 
 int ControlOSC::_dummy_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 #ifdef DEBUG
 	cerr << "got path: " << path << endl;
@@ -522,7 +522,7 @@ int ControlOSC::_dummy_handler(const char *path, const char *types, lo_arg **arg
 
 
 int ControlOSC::_quit_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->quit_handler (path, types, argv, argc, data);
@@ -530,7 +530,7 @@ int ControlOSC::_quit_handler(const char *path, const char *types, lo_arg **argv
 }
 
 int ControlOSC::_ping_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->ping_handler (path, types, argv, argc, data);
@@ -538,14 +538,14 @@ int ControlOSC::_ping_handler(const char *path, const char *types, lo_arg **argv
 }
 
 int ControlOSC::_global_set_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_set_handler (path, types, argv, argc, data);
 
 }
 int ControlOSC::_global_get_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_get_handler (path, types, argv, argc, data);
@@ -554,140 +554,140 @@ int ControlOSC::_global_get_handler(const char *path, const char *types, lo_arg 
 
 
 int ControlOSC::_updown_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->updown_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_set_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->set_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_get_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->get_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->set_prop_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->get_prop_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->register_update_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->unregister_update_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->register_auto_update_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->unregister_auto_update_handler (path, types, argv, argc, data, cp);
 }
 
-int ControlOSC::_loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->loop_add_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->loop_del_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->load_session_handler (path, types, argv, argc, data);
 }
-int ControlOSC::_save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->save_session_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_register_config_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->register_config_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->unregister_config_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->loadloop_handler (path, types, argv, argc, data, cp);
 }
 
-int ControlOSC::_saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data)
 {
 	CommandInfo * cp = static_cast<CommandInfo*> (user_data);
 	return cp->osc->saveloop_handler (path, types, argv, argc, data, cp);
 }
 
 int ControlOSC::_global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_register_update_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_unregister_update_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_register_auto_update_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->global_unregister_auto_update_handler (path, types, argv, argc, data);
@@ -695,27 +695,27 @@ int ControlOSC::_global_unregister_auto_update_handler(const char *path, const c
 
 
 int ControlOSC::_midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->midi_start_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->midi_stop_handler (path, types, argv, argc, data);
 }
 
 int ControlOSC::_midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	ControlOSC * osc = static_cast<ControlOSC*> (user_data);
 	return osc->midi_tick_handler (path, types, argv, argc, data);
 }
 
-int ControlOSC::_midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data)
+int ControlOSC::_midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data)
 {
 	MidiBindCommand * cp = static_cast<MidiBindCommand*> (user_data);
 	return cp->osc->midi_binding_handler (path, types, argv, argc, data, cp);

--- a/src/control_osc.hpp
+++ b/src/control_osc.hpp
@@ -118,39 +118,39 @@ class ControlOSC
 	lo_address find_or_cache_addr(std::string returl);
 
 	
-	static int _quit_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_set_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_get_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _updown_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _set_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _get_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _dummy_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _ping_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
+	static int _quit_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _global_set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _global_get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _updown_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _set_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _get_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _set_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _get_prop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _dummy_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _ping_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _loop_add_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _loop_del_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _load_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _save_session_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _register_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _unregister_config_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _loadloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _saveloop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _global_register_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _global_unregister_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _global_register_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _global_unregister_auto_update_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
 
 	
-	static int _midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-	static int _midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
+	static int _midi_start_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _midi_stop_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
+	static int _midi_tick_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
 
-	static int _midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
+	static int _midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message_ *data, void *user_data);
 
 
 	bool init_osc_thread();

--- a/src/gui/loop_control.cpp
+++ b/src/gui/loop_control.cpp
@@ -663,7 +663,7 @@ bool LoopControl::spawn_looper()
 
 int
 LoopControl::_pingack_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message_ *data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->pingack_handler (path, types, argv, argc, data);
@@ -758,7 +758,7 @@ LoopControl::pingack_handler(const char *path, const char *types, lo_arg **argv,
 
 int
 LoopControl::_alive_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message_ *data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->alive_handler (path, types, argv, argc, data);
@@ -782,7 +782,7 @@ LoopControl::alive_handler(const char *path, const char *types, lo_arg **argv, i
 
 int
 LoopControl::_error_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message_ *data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->error_handler (path, types, argv, argc, data);
@@ -803,7 +803,7 @@ LoopControl::error_handler(const char *path, const char *types, lo_arg **argv, i
 
 int
 LoopControl::_control_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message_ *data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->control_handler (path, types, argv, argc, data);
@@ -858,7 +858,7 @@ LoopControl::control_handler(const char *path, const char *types, lo_arg **argv,
 
 int
 LoopControl::_property_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message_ *data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->property_handler (path, types, argv, argc, data);
@@ -894,7 +894,7 @@ LoopControl::property_handler(const char *path, const char *types, lo_arg **argv
 
 int
 LoopControl::_midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data)
+			      lo_message_ *data, void *user_data)
 {
 	LoopControl * lc = static_cast<LoopControl*> (user_data);
 	return lc->midi_binding_handler (path, types, argv, argc, data);

--- a/src/gui/loop_control.hpp
+++ b/src/gui/loop_control.hpp
@@ -171,32 +171,32 @@ class LoopControl
   protected:
 	
 	static int _control_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message_ *data, void *user_data);
 
 	int control_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
 
 	static int _property_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message_ *data, void *user_data);
 
 	int property_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
 
 	static int _pingack_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message_ *data, void *user_data);
 
 	int pingack_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
 
 	static int _midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message_ *data, void *user_data);
 
 	int midi_binding_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
 
 	static int _alive_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message_ *data, void *user_data);
 
 	int alive_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
 
 	static int _error_handler(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    lo_message_ *data, void *user_data);
 
 	int error_handler(const char *path, const char *types, lo_arg **argv, int argc, void *data);
 	

--- a/src/slconsole.cpp
+++ b/src/slconsole.cpp
@@ -273,7 +273,7 @@ static int post_event(char cmd)
 }
 
 static int ctrl_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	// 1st arg is instance, 2nd ctrl string, 3nd is float value
 	//int index = argv[0]->i;
@@ -288,7 +288,7 @@ static int ctrl_handler(const char *path, const char *types, lo_arg **argv, int 
 }
 
 static int pingack_handler(const char *path, const char *types, lo_arg **argv, int argc,
-			 void *data, void *user_data)
+			 lo_message_ *data, void *user_data)
 {
 	// pingack expects: s:engine_url s:version i:loopcount
 	// 1st arg is instance, 2nd ctrl string, 3nd is float value


### PR DESCRIPTION
SooperLooper won't compile against liblo-0.32 (in use by Arch Linux) because the library changed the type of one of the handler function args from *void to *lo_message_. This change gets it to compile on my machine.